### PR TITLE
feature: Episode pages, including transcripts

### DIFF
--- a/src/components/Episode.tsx
+++ b/src/components/Episode.tsx
@@ -27,18 +27,8 @@ export const Episode: React.FC<{ episode: EpisodeDetails; full?: boolean }> = ({
           </h3>
         </div>
         <div className="episodeMeta">
-          <img
-            src="https://github.com/benjie.png"
-            width="20"
-            height="20"
-            alt="Benjie"
-          />
-          <img
-            src="https://github.com/jemgillam.png"
-            width="20"
-            height="20"
-            alt="Jem"
-          />
+          <img src="/avatar/benjie.png" width="20" height="20" alt="Benjie" />
+          <img src="/avatar/jem.jpg" width="20" height="20" alt="Jem" />
           <span>{episode.date}</span>
         </div>
         <div>{episode.description}</div>

--- a/src/components/Episode.tsx
+++ b/src/components/Episode.tsx
@@ -2,13 +2,30 @@ import * as React from "react";
 import type { EpisodeDetails } from "../episodes/interfaces";
 import { AnchorEmbed } from "./AnchorEmbed";
 
-export const Episode: React.FC<{ episode: EpisodeDetails }> = ({ episode }) => {
+export const Episode: React.FC<{ episode: EpisodeDetails; full?: boolean }> = ({
+  episode,
+  full = false,
+}) => {
   return (
     <div className="episode">
       <div className="episodeArt"></div>
       <div className="episodeMain">
-        <h5 id={episode.id}>{episode.supertitle}</h5>
-        <h3>{episode.title}</h3>
+        <div className="episodeTitles">
+          <h5 id={episode.id}>
+            {full ? (
+              episode.supertitle
+            ) : (
+              <a href={`/${episode.id}`}>{episode.supertitle}</a>
+            )}
+          </h5>
+          <h3>
+            {full ? (
+              episode.title
+            ) : (
+              <a href={`/${episode.id}`}>{episode.title}</a>
+            )}
+          </h3>
+        </div>
         <div className="episodeMeta">
           <img
             src="https://github.com/benjie.png"

--- a/src/components/EpisodePage.tsx
+++ b/src/components/EpisodePage.tsx
@@ -27,8 +27,6 @@ export const EpisodePage: FC<{ episode: EpisodeDetails }> = ({ episode }) => {
       <Hero episode={episode} />
       <div className="main">
         <main>
-          <AnchorEmbed src={episode.embed} />
-
           {episode.transcript ? (
             <div>
               <h2>Transcript</h2>

--- a/src/components/EpisodePage.tsx
+++ b/src/components/EpisodePage.tsx
@@ -1,8 +1,7 @@
 import React, { FC, ReactElement, ReactNode } from "react";
 import { renderToString } from "react-dom/server";
+import "../styles/index.css";
 import { EpisodeDetails } from "../episodes";
-import { AnchorEmbed } from "./AnchorEmbed";
-import { Episode } from "./Episode";
 import { Hero } from "./Hero";
 import { Meta } from "./Meta";
 

--- a/src/components/EpisodePage.tsx
+++ b/src/components/EpisodePage.tsx
@@ -27,6 +27,7 @@ export const EpisodePage: FC<{ episode: EpisodeDetails }> = ({ episode }) => {
       <Hero episode={episode} />
       <div className="main">
         <main>
+          <div>{episode.description}</div>
           {episode.transcript ? (
             <div>
               <h2>Transcript</h2>

--- a/src/components/EpisodePage.tsx
+++ b/src/components/EpisodePage.tsx
@@ -1,0 +1,42 @@
+import React, { FC, ReactElement, ReactNode } from "react";
+import { renderToString } from "react-dom/server";
+import { EpisodeDetails } from "../episodes";
+import { AnchorEmbed } from "./AnchorEmbed";
+import { Episode } from "./Episode";
+import { Hero } from "./Hero";
+import { Meta } from "./Meta";
+
+function reactToText(el: ReactElement): string {
+  const str = renderToString(el);
+  return str
+    .replace(/(<\/p>|<br\s*\/?>)/g, "\n")
+    .replace(/<[^>]+>/g, "")
+    .trim();
+}
+
+export const EpisodePage: FC<{ episode: EpisodeDetails }> = ({ episode }) => {
+  return (
+    <div>
+      <Meta
+        title={episode.supertitle + ": " + episode.title}
+        url={`https://specnewspod.com/${episode.id}`}
+        description={
+          episode.description ? reactToText(episode.description) : undefined
+        }
+      />
+      <Hero episode={episode} />
+      <div className="main">
+        <main>
+          <AnchorEmbed src={episode.embed} />
+
+          {episode.transcript ? (
+            <div>
+              <h2>Transcript</h2>
+              {episode.transcript}
+            </div>
+          ) : null}
+        </main>
+      </div>
+    </div>
+  );
+};

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -1,0 +1,104 @@
+import React, { FC } from "react";
+import { EpisodeDetails } from "../episodes";
+import { AnchorEmbed } from "./AnchorEmbed";
+import { Channel } from "./Channel";
+import { SignupFormLight } from "./SignupForm";
+
+export const Hero: FC<{ episode?: EpisodeDetails }> = ({ episode }) => {
+  return (
+    <>
+      <div className="header">
+        <div className="headerInner">
+          <div className="headerText">
+            {episode ? (
+              <>
+                <h3>{episode.supertitle}</h3>
+                <h1>{episode.title}</h1>
+              </>
+            ) : (
+              <h1>GraphQL Working Group updates in minutes</h1>
+            )}
+            <div className="headerWho">
+              <div className="headerPerson">
+                <div className="headerPersonAvatar">
+                  <img
+                    src="/avatar/benjie.png"
+                    width="64"
+                    height="64"
+                    alt="Benjie"
+                  />
+                </div>
+                <div className="headerPersonName">
+                  <a href="https://twitter.com/Benjie">@Benjie</a>
+                </div>
+              </div>
+              <div className="headerPerson">
+                <div className="headerPersonAvatar">
+                  <img src="/avatar/jem.jpg" width="64" height="64" alt="Jem" />
+                </div>
+                <div className="headerPersonName">
+                  <a href="https://twitter.com/JemGillam">@JemGillam</a>
+                </div>
+              </div>
+            </div>
+            <p className="lead">
+              {episode ? (
+                episode.description
+              ) : (
+                <>
+                  <strong>SpecNews</strong> digests the latest GraphQL Working
+                  Group happenings and delivers the highlights straight to your
+                  ears, so you can stay up to date in just a few minutes every
+                  month.
+                </>
+              )}
+            </p>
+            {episode ? <AnchorEmbed src={episode.embed} /> : null}
+            <hr />
+            <SignupFormLight />
+            {/*
+            <p>Subscribe to be notified of new episodes of SpecNews:</p>
+            <form className="subscribe">
+              <input placeholder="yourname@example.com" />
+              <button type="submit">Subscribe</button>
+            </form>
+            */}
+            <div className="channels">
+              <Channel
+                name="Spotify"
+                logo="/logo/spotify-brands.svg"
+                url="https://open.spotify.com/show/69vo1Wrlda6EP3EzIZnzjf"
+                title="Subscribe to SpecNews on Spotify"
+              />
+              <Channel
+                name="Apple"
+                logo="/logo/podcast-solid.svg"
+                url="https://podcasts.apple.com/us/podcast/specnews-graphql-digests/id1628494077"
+                title="Subscribe to SpecNews on Apple Podcasts"
+              />
+              <Channel
+                name="RSS"
+                logo="/logo/square-rss-solid.svg"
+                url="https://anchor.fm/s/9c882588/podcast/rss"
+                title="Subscribe via RSS"
+              />
+              <Channel
+                name="Twitter"
+                logo="/logo/twitter-brands.svg"
+                url="https://twitter.com/SpecNewsPod"
+                title="Follow @SpecNewsPod on Twitter"
+              />
+            </div>
+            {episode ? (
+              <a className="back" href="/">
+                &laquo; Back to episodes
+              </a>
+            ) : null}
+          </div>
+          <div className="headerGap"></div>
+          <div className="headerLogo"></div>
+        </div>
+      </div>
+    </>
+  );
+};

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -43,7 +43,10 @@ export const Hero: FC<{ episode?: EpisodeDetails }> = ({ episode }) => {
             </div>
             <p className="lead">
               {episode ? (
-                episode.description
+                <div>
+                  {episode.description}
+                  Find the transcript below
+                </div>
               ) : (
                 <>
                   <strong>SpecNews</strong> digests the latest GraphQL Working
@@ -55,7 +58,7 @@ export const Hero: FC<{ episode?: EpisodeDetails }> = ({ episode }) => {
             </p>
             {episode ? <AnchorEmbed src={episode.embed} /> : null}
             <hr />
-            <SignupFormLight />
+            {episode ? null : <SignupFormLight />}
             {/*
             <p>Subscribe to be notified of new episodes of SpecNews:</p>
             <form className="subscribe">

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -12,6 +12,9 @@ export const Hero: FC<{ episode?: EpisodeDetails }> = ({ episode }) => {
           <div className="headerText">
             {episode ? (
               <>
+                <a className="close" href="/">
+                  X
+                </a>
                 <h3>{episode.supertitle}</h3>
                 <h1>{episode.title}</h1>
               </>
@@ -52,12 +55,8 @@ export const Hero: FC<{ episode?: EpisodeDetails }> = ({ episode }) => {
               )}
             </p>
             {episode ? <AnchorEmbed src={episode.embed} /> : null}
-            <hr />
-            {episode ? (
-              <a className="back" href="/">
-                &laquo; Back to episodes
-              </a>
-            ) : (
+            {episode ? null : <hr />}
+            {episode ? null : (
               <div>
                 <SignupFormLight />
                 <div className="channels">

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -42,12 +42,7 @@ export const Hero: FC<{ episode?: EpisodeDetails }> = ({ episode }) => {
               </div>
             </div>
             <p className="lead">
-              {episode ? (
-                <div>
-                  {episode.description}
-                  Find the transcript below
-                </div>
-              ) : (
+              {episode ? null : (
                 <>
                   <strong>SpecNews</strong> digests the latest GraphQL Working
                   Group happenings and delivers the highlights straight to your
@@ -58,48 +53,44 @@ export const Hero: FC<{ episode?: EpisodeDetails }> = ({ episode }) => {
             </p>
             {episode ? <AnchorEmbed src={episode.embed} /> : null}
             <hr />
-            {episode ? null : <SignupFormLight />}
-            {/*
-            <p>Subscribe to be notified of new episodes of SpecNews:</p>
-            <form className="subscribe">
-              <input placeholder="yourname@example.com" />
-              <button type="submit">Subscribe</button>
-            </form>
-            */}
-            <div className="channels">
-              <Channel
-                name="Spotify"
-                logo="/logo/spotify-brands.svg"
-                url="https://open.spotify.com/show/69vo1Wrlda6EP3EzIZnzjf"
-                title="Subscribe to SpecNews on Spotify"
-              />
-              <Channel
-                name="Apple"
-                logo="/logo/podcast-solid.svg"
-                url="https://podcasts.apple.com/us/podcast/specnews-graphql-digests/id1628494077"
-                title="Subscribe to SpecNews on Apple Podcasts"
-              />
-              <Channel
-                name="RSS"
-                logo="/logo/square-rss-solid.svg"
-                url="https://anchor.fm/s/9c882588/podcast/rss"
-                title="Subscribe via RSS"
-              />
-              <Channel
-                name="Twitter"
-                logo="/logo/twitter-brands.svg"
-                url="https://twitter.com/SpecNewsPod"
-                title="Follow @SpecNewsPod on Twitter"
-              />
-            </div>
             {episode ? (
               <a className="back" href="/">
                 &laquo; Back to episodes
               </a>
-            ) : null}
+            ) : (
+              <div>
+                <SignupFormLight />
+                <div className="channels">
+                  <Channel
+                    name="Spotify"
+                    logo="/logo/spotify-brands.svg"
+                    url="https://open.spotify.com/show/69vo1Wrlda6EP3EzIZnzjf"
+                    title="Subscribe to SpecNews on Spotify"
+                  />
+                  <Channel
+                    name="Apple"
+                    logo="/logo/podcast-solid.svg"
+                    url="https://podcasts.apple.com/us/podcast/specnews-graphql-digests/id1628494077"
+                    title="Subscribe to SpecNews on Apple Podcasts"
+                  />
+                  <Channel
+                    name="RSS"
+                    logo="/logo/square-rss-solid.svg"
+                    url="https://anchor.fm/s/9c882588/podcast/rss"
+                    title="Subscribe via RSS"
+                  />
+                  <Channel
+                    name="Twitter"
+                    logo="/logo/twitter-brands.svg"
+                    url="https://twitter.com/SpecNewsPod"
+                    title="Follow @SpecNewsPod on Twitter"
+                  />
+                </div>
+              </div>
+            )}
           </div>
           <div className="headerGap"></div>
-          <div className="headerLogo"></div>
+          {episode ? null : <div className="headerLogo"></div>}
         </div>
       </div>
     </>

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -13,7 +13,7 @@ export const Hero: FC<{ episode?: EpisodeDetails }> = ({ episode }) => {
             {episode ? (
               <>
                 <a className="close" href="/">
-                  X
+                  &times;
                 </a>
                 <h3>{episode.supertitle}</h3>
                 <h1>{episode.title}</h1>

--- a/src/components/Meta.tsx
+++ b/src/components/Meta.tsx
@@ -1,0 +1,43 @@
+import React, { FC } from "react";
+import { Helmet } from "react-helmet";
+
+export const Meta: FC<{
+  title?: string;
+  url?: string;
+  description?: string;
+}> = ({ title, url, description }) => (
+  <Helmet
+    title={
+      title ??
+      "SpecNews: a podcast delivering the latest highlights from the GraphQL Working Group"
+    }
+    defer={false}
+  >
+    <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
+    <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
+    <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png" />
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content={url ?? "https://specnewspod.com/"} />
+    <meta
+      property="og:title"
+      content={title ?? "SpecNews: GraphQL WG Digests"}
+    />
+    <meta
+      property="og:description"
+      content={
+        description ??
+        "The latest GraphQL Working Group highlights straight to your ears; stay up to date in just a few minutes every month!"
+      }
+    />
+    <meta
+      property="og:image"
+      content="https://specnewspod.com/logo/SpecNews.png"
+    />
+    <link
+      type="application/rss+xml"
+      rel="alternate"
+      title="SpecNews: GraphQL digests"
+      href="https://anchor.fm/s/9c882588/podcast/rss"
+    />
+  </Helmet>
+);

--- a/src/components/Transcript.tsx
+++ b/src/components/Transcript.tsx
@@ -21,13 +21,13 @@ export const Speech: FC<
 );
 
 export const B: FC<PropsWithChildren> = ({ children }) => (
-  <Speech name="Benjie" avatarUrl="https://github.com/benjie.png">
+  <Speech name="Benjie" avatarUrl="/avatar/benjie.png">
     {children}
   </Speech>
 );
 
 export const J: FC<PropsWithChildren> = ({ children }) => (
-  <Speech name="Jem" avatarUrl="https://github.com/jemgillam.png">
+  <Speech name="Jem" avatarUrl="/avatar/jem.jpg">
     {children}
   </Speech>
 );

--- a/src/components/Transcript.tsx
+++ b/src/components/Transcript.tsx
@@ -1,6 +1,10 @@
 import React, { FC, PropsWithChildren } from "react";
 import { SignupFormLight } from "./SignupForm";
 
+interface X {
+  x?: boolean;
+}
+
 export const Transcript: FC<PropsWithChildren> = ({ children }) => (
   <div>
     <div className="transcript">{children}</div>
@@ -17,25 +21,40 @@ export const Avatar: FC<{ url: string; alt: string }> = ({ url, alt }) => (
 );
 
 export const Speech: FC<
-  PropsWithChildren<{ name: string; avatarUrl: string }>
-> = ({ name, avatarUrl, children }) => (
-  <div className="transcriptEntry">
-    <div className="transcriptSpeaker">
-      <Avatar url={avatarUrl} alt={name} />
-      <div className="transcriptSpeakerName">{name}</div>
-    </div>
-    <div className="transcriptText">{children}</div>
-  </div>
-);
+  PropsWithChildren<{ name: string; avatarUrl: string } & X>
+> = ({ name, avatarUrl, children, x }) => {
+  if (x && false) {
+    return (
+      <div className="transcriptEntryShort">
+        <div className="avatarShort">
+          <Avatar url={avatarUrl} alt={name} />
+        </div>
+        <div className="bodyShort">
+          <span className="transcriptSpeakerNameShort">{name}</span> {children}
+        </div>
+      </div>
+    );
+  } else {
+    return (
+      <div className={`transcriptEntry ${x ? "short" : ""}`}>
+        <div className="transcriptSpeaker">
+          <Avatar url={avatarUrl} alt={name} />
+          <div className="transcriptSpeakerName">{name}</div>
+        </div>
+        <div className="transcriptText">{children}</div>
+      </div>
+    );
+  }
+};
 
-export const B: FC<PropsWithChildren> = ({ children }) => (
-  <Speech name="Benjie" avatarUrl="/avatar/benjie.png">
+export const B: FC<PropsWithChildren<X>> = ({ children, x }) => (
+  <Speech x={x} name="Benjie" avatarUrl="/avatar/benjie.png">
     {children}
   </Speech>
 );
 
-export const J: FC<PropsWithChildren> = ({ children }) => (
-  <Speech name="Jem" avatarUrl="/avatar/jem.jpg">
+export const J: FC<PropsWithChildren<X>> = ({ children, x }) => (
+  <Speech x={x} name="Jem" avatarUrl="/avatar/jem.jpg">
     {children}
   </Speech>
 );

--- a/src/components/Transcript.tsx
+++ b/src/components/Transcript.tsx
@@ -1,22 +1,22 @@
 import React, { FC, PropsWithChildren } from "react";
 
 export const Transcript: FC<PropsWithChildren> = ({ children }) => (
-  <div>{children}</div>
+  <div className="transcript">{children}</div>
 );
 
 export const Avatar: FC<{ url: string; alt: string }> = ({ url, alt }) => (
-  <img width="20" height="20" src={url} alt={alt} />
+  <img className="transcriptSpeakerAvatar" src={url} alt={alt} />
 );
 
 export const Speech: FC<
   PropsWithChildren<{ name: string; avatarUrl: string }>
 > = ({ name, avatarUrl, children }) => (
-  <div>
-    <div>
+  <div className="transcriptEntry">
+    <div className="transcriptSpeaker">
       <Avatar url={avatarUrl} alt={name} />
-      {name}
+      <div className="transcriptSpeakerName">{name}</div>
     </div>
-    <div>{children}</div>
+    <div className="transcriptText">{children}</div>
   </div>
 );
 

--- a/src/components/Transcript.tsx
+++ b/src/components/Transcript.tsx
@@ -1,7 +1,16 @@
 import React, { FC, PropsWithChildren } from "react";
+import { SignupFormLight } from "./SignupForm";
+
 
 export const Transcript: FC<PropsWithChildren> = ({ children }) => (
-  <div className="transcript">{children}</div>
+  <div>
+    <div className="transcript">{children}</div>
+    <hr />
+    <SignupFormLight />
+    <a className="back" href="/">
+      &laquo; Back to episodes
+    </a>
+  </div>
 );
 
 export const Avatar: FC<{ url: string; alt: string }> = ({ url, alt }) => (

--- a/src/components/Transcript.tsx
+++ b/src/components/Transcript.tsx
@@ -1,0 +1,33 @@
+import React, { FC, PropsWithChildren } from "react";
+
+export const Transcript: FC<PropsWithChildren> = ({ children }) => (
+  <div>{children}</div>
+);
+
+export const Avatar: FC<{ url: string; alt: string }> = ({ url, alt }) => (
+  <img width="20" height="20" src={url} alt={alt} />
+);
+
+export const Speech: FC<
+  PropsWithChildren<{ name: string; avatarUrl: string }>
+> = ({ name, avatarUrl, children }) => (
+  <div>
+    <div>
+      <Avatar url={avatarUrl} alt={name} />
+      {name}
+    </div>
+    <div>{children}</div>
+  </div>
+);
+
+export const B: FC<PropsWithChildren> = ({ children }) => (
+  <Speech name="Benjie" avatarUrl="https://github.com/benjie.png">
+    {children}
+  </Speech>
+);
+
+export const J: FC<PropsWithChildren> = ({ children }) => (
+  <Speech name="Jem" avatarUrl="https://github.com/jemgillam.png">
+    {children}
+  </Speech>
+);

--- a/src/components/Transcript.tsx
+++ b/src/components/Transcript.tsx
@@ -1,7 +1,6 @@
 import React, { FC, PropsWithChildren } from "react";
 import { SignupFormLight } from "./SignupForm";
 
-
 export const Transcript: FC<PropsWithChildren> = ({ children }) => (
   <div>
     <div className="transcript">{children}</div>
@@ -43,8 +42,6 @@ export const J: FC<PropsWithChildren> = ({ children }) => (
 
 export const Timestamp: FC<PropsWithChildren> = ({ children }) => (
   <div className="transcriptEntry">
-    <h4 className="timestamp">
-      {children}
-    </h4>
+    <h4 className="timestamp">{children}</h4>
   </div>
 );

--- a/src/components/Transcript.tsx
+++ b/src/components/Transcript.tsx
@@ -40,3 +40,11 @@ export const J: FC<PropsWithChildren> = ({ children }) => (
     {children}
   </Speech>
 );
+
+export const Timestamp: FC<PropsWithChildren> = ({ children }) => (
+  <div className="transcriptEntry">
+    <h4 className="timestamp">
+      {children}
+    </h4>
+  </div>
+);

--- a/src/components/Transcript.tsx
+++ b/src/components/Transcript.tsx
@@ -45,3 +45,6 @@ export const Timestamp: FC<PropsWithChildren> = ({ children }) => (
     <h4 className="timestamp">{children}</h4>
   </div>
 );
+export const Code: FC<PropsWithChildren> = ({ children }) => (
+  <span className="code">{children}</span>
+);

--- a/src/episodes/0000.tsx
+++ b/src/episodes/0000.tsx
@@ -26,30 +26,30 @@ export const ep0000: EpisodeDetails = {
   ),
   transcript: (
     <Transcript>
-      <B>Hey folks; welcome to Spec News, a new podcast from me, Benjie</B>
-      <J>
+      <B x>Hey folks; welcome to Spec News, a new podcast from me, Benjie</B>
+      <J x>
         and from me, Jem. Since 2019 Benjie's been taking notes at most of the
         GraphQL Working Group sessions and then giving me the rundown
         afterwards.
       </J>
-      <B>
+      <B x>
         We figured, since I'm already producing a summary for one person, why
         not extend that to everyone?
       </B>
-      <J>And since we both wear spectacles Spec News was born</J>
-      <B>the name of course having nothing to do with the GraphQL Spec.</B>
-      <J>
+      <J x>And since we both wear spectacles Spec News was born</J>
+      <B x>the name of course having nothing to do with the GraphQL Spec.</B>
+      <J x>
         Of course. Anyway, join us each month for a quickfire summary of the
         latest developments in the GraphQL Working Group
       </J>
-      <B>
+      <B x>
         and perhaps some bonus episodes from time to time spotlighting
         particular proposals
       </B>
-      <J>and people!</J>
-      <B>that are helping to advance GraphQL.</B>
-      <J>Speak to you soon</J>
-      <B>and don't forget your specs!</B>
+      <J x>and people!</J>
+      <B x>that are helping to advance GraphQL.</B>
+      <J x>Speak to you soon</J>
+      <B x>and don't forget your specs!</B>
     </Transcript>
   ),
 };

--- a/src/episodes/0000.tsx
+++ b/src/episodes/0000.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import type { EpisodeDetails } from "./interfaces";
+import { Transcript, J, B } from "../components/Transcript";
 
 export const ep0000: EpisodeDetails = {
   id: "ep0000",
@@ -22,5 +23,33 @@ export const ep0000: EpisodeDetails = {
         .
       </p>
     </div>
+  ),
+  transcript: (
+    <Transcript>
+      <B>Hey folks; welcome to Spec News, a new podcast from me, Benjie</B>
+      <J>
+        and from me, Jem. Since 2019 Benjie's been taking notes at most of the
+        GraphQL Working Group sessions and then giving me the rundown
+        afterwards.
+      </J>
+      <B>
+        We figured, since I'm already producing a summary for one person, why
+        not extend that to everyone?
+      </B>
+      <J>And since we both wear spectacles Spec News was born</J>
+      <B>the name of course having nothing to do with the GraphQL Spec.</B>
+      <J>
+        Of course. Anyway, join us each month for a quickfire summary of the
+        latest developments in the GraphQL Working Group
+      </J>
+      <B>
+        and perhaps some bonus episodes from time to time spotlighting
+        particular proposals
+      </B>
+      <J>and people!</J>
+      <B>that are helping to advance GraphQL.</B>
+      <J>Speak to you soon</J>
+      <B>and don't forget your specs!</B>
+    </Transcript>
   ),
 };

--- a/src/episodes/0001.tsx
+++ b/src/episodes/0001.tsx
@@ -32,22 +32,22 @@ export const ep0001: EpisodeDetails = {
   ),
   transcript: (
     <Transcript>
-      <B>Welcome to episode 1 of Spec News</B>
-      <J>
+      <B x>Welcome to episode 1 of Spec News</B>
+      <J x>
         keeping you up to date with advances in the GraphQL Spec and related
         foundation projects.
       </J>
-      <B>We&apos;re your bespectacled hosts: I&apos;m Benjie</B>
-      <J>
+      <B x>We&apos;re your bespectacled hosts: I&apos;m Benjie</B>
+      <J x>
         and I&apos;m Jem.
-        <p>
-          April&apos;s working group saw the announcement of the GraphQL
-          Foundation&apos;s first Conference
-        </p>
+        <br />
+        <br />
+        April&apos;s working group saw the announcement of the GraphQL
+        Foundation&apos;s first Conference
       </J>
-      <B>a preview of the future direction of GraphiQL</B>
-      <J>a proposal to allow unions to implement interfaces</J>
-      <B>and a discussion of the payload format to use for streams</B>
+      <B x>a preview of the future direction of GraphiQL</B>
+      <J x>a proposal to allow unions to implement interfaces</J>
+      <B x>and a discussion of the payload format to use for streams</B>
       <Timestamp>[0:33] GraphQL Foundation Conference</Timestamp>
       <J>
         The first item was rather exciting&mdash;Lee introduced the{" "}
@@ -66,7 +66,7 @@ export const ep0001: EpisodeDetails = {
       </B>
       <Timestamp>[1:11] Update on GraphiQL</Timestamp>
       <J>Tim joined us to give us an update on the GraphiQL&mdash;</J>
-      <B>that&apos;s &quot;Graph i Q L&quot;: the GraphQL IDE</B>
+      <B x>that&apos;s &quot;Graph i Q L&quot;: the GraphQL IDE</B>
       <J>
         &mdash;version 2 design proposals. What was presented looks fantastic: a
         minimalist and flexible design that expands as you become more familiar.
@@ -109,7 +109,7 @@ export const ep0001: EpisodeDetails = {
         the payload format to use for streams. It was established that nulls
         must bubble only to the boundary of the payload and no further
       </J>
-      <B>(since you can&apos;t go back in time)</B>
+      <B x>(since you can&apos;t go back in time)</B>
       <J>
         indeed; however the challenge is in distinguishing between actual nulls
         and errors.

--- a/src/episodes/0001.tsx
+++ b/src/episodes/0001.tsx
@@ -11,8 +11,8 @@ export const ep0001: EpisodeDetails = {
   description: (
     <div>
       <p>
-        April 2022’s working group saw the announcement of the GraphQL
-        Foundation’s first conference, a preview of the future direction of
+        April 2022&apos;s working group saw the announcement of the GraphQL
+        Foundation&apos;s first conference, a preview of the future direction of
         GraphiQL, a proposal to allow unions to implement interfaces, and a
         discussion of the payload format to use for streams. Jem and Benjie give
         you the lowdown.
@@ -37,12 +37,12 @@ export const ep0001: EpisodeDetails = {
         keeping you up to date with advances in the GraphQL Spec and related
         foundation projects.
       </J>
-      <B>We're your bespectacled hosts: I'm Benjie</B>
+      <B>We&apos;re your bespectacled hosts: I&apos;m Benjie</B>
       <J>
-        and I'm Jem.
+        and I&apos;m Jem.
         <p>
-          April’s working group saw the announcement of the GraphQL Foundation’s
-          first Conference
+          April&apos;s working group saw the announcement of the GraphQL
+          Foundation&apos;s first Conference
         </p>
       </J>
       <B>a preview of the future direction of GraphiQL</B>
@@ -50,44 +50,43 @@ export const ep0001: EpisodeDetails = {
       <B>and a discussion of the payload format to use for streams</B>
       <Timestamp>[0:33] GraphQL Foundation Conference</Timestamp>
       <J>
-        The first item was rather exciting - Lee introduced the{" "}
+        The first item was rather exciting&mdash;Lee introduced the{" "}
         <a href="https://graphql.org/foundation/graphql-conf/" target="_new">
           first official conference organised by the GraphQL Foundation
         </a>
         . To make things easier, the conference will be colocated with
-        OpenJSWorld on June 7th and 8th in Austin, but it's important to note
-        that the GraphQL part is not JavaScript-specific!
+        OpenJSWorld on June 7th and 8th in Austin, but it&apos;s important to
+        note that the GraphQL part is not JavaScript&#8208;specific!
       </J>
       <B>
-        Rather than being an end-user conference, the audience is expected to
-        consist of working group attendees, GraphQL implementers, and other
+        Rather than being an end&#8208;user conference, the audience is expected
+        to consist of working group attendees, GraphQL implementers, and other
         people well versed in topics around the GraphQL specification. Very
-        exciting - get your talk submissions in now!
+        exciting&mdash;get your talk submissions in now!
       </B>
       <Timestamp>[1:11] Update on GraphiQL</Timestamp>
       <J>Tim joined us to give us an update on the GraphiQL&mdash;</J>
-      <B>that's Graph i Q L – the GraphQL IDE</B>
+      <B>that&apos;s &quot;Graph i Q L&quot;: the GraphQL IDE</B>
       <J>
-        &mdash;version 2 design proposals. What was presented looks fantastic -
-        a minimalist and flexible design that expands as you become more
-        familiar. The reception was very positive, tempered only by the working
-        group attendees suggesting improvements to the design, for example
-        allowing additional space for longer-form markdown documentation,
-        improving discoverability of variables, and other such matters. I hope
-        Tim found the feedback helpful and we can't wait to see the project
-        advance!
+        &mdash;version 2 design proposals. What was presented looks fantastic: a
+        minimalist and flexible design that expands as you become more familiar.
+        The reception was very positive, tempered only by the working group
+        attendees suggesting improvements to the design, for example allowing
+        additional space for longer&#8208;form markdown documentation, improving
+        discoverability of variables, and other such matters. I hope Tim found
+        the feedback helpful and we can&apos;t wait to see the project advance!
       </J>
       <Timestamp>[1:54] Unions declaring interfaces</Timestamp>
       <B>
         Next up was Yaacov with a proposal to allow unions to declare
         implementation of interfaces. After some discussion this boiled down to
-        a constraint - the union doesn't itself implement the interfaces,
-        instead it requires that all object types within it implement the
-        interfaces - an interesting proposal. The working group pushed Yaacov to
-        consider allowing fields in the interface to be resolved directly on the
-        selection set (without the need for a fragment) for consistency with
-        interfaces elsewhere in the spec. The balance as always is between
-        simplicity and power.
+        a constraint&mdash;the union doesn&apos;t itself implement the
+        interfaces, instead it requires that all object types within it
+        implement the interfaces&mdash;an interesting proposal. The working
+        group pushed Yaacov to consider allowing fields in the interface to be
+        resolved directly on the selection set (without the need for a fragment)
+        for consistency with interfaces elsewhere in the spec. The balance as
+        always is between simplicity and power.
       </B>
       <J>
         To advance the proposal further, Lee suggested that Yaacov:
@@ -97,11 +96,11 @@ export const ep0001: EpisodeDetails = {
           </li>
           <li>looks for and documents precedent from other languages;</li>
           <li>
-            and considers if a different keyword rather than "implements" would
-            make sense.
+            and considers if a different keyword rather than
+            &quot;implements&quot; would make sense.
           </li>
         </ul>
-        The proposal was advanced to RFC stage 1 - &quot;Proposal&quot;.
+        The proposal was advanced to RFC stage 1: &quot;Proposal&quot;.
       </J>
       <B>And may well make it harder for me to deprecate unions!</B>
       <Timestamp>[3:01] The payload format to use for streams</Timestamp>
@@ -110,7 +109,7 @@ export const ep0001: EpisodeDetails = {
         the payload format to use for streams. It was established that nulls
         must bubble only to the boundary of the payload and no further
       </J>
-      <B>(since you can't go back in time)</B>
+      <B>(since you can&apos;t go back in time)</B>
       <J>
         indeed; however the challenge is in distinguishing between actual nulls
         and errors.
@@ -130,23 +129,24 @@ export const ep0001: EpisodeDetails = {
           included in the payload, and if so: where? One consideration here is
           potential future batching which was discussed in some depth, along
           with possible payload shapes for including multiple stream or defer
-          payloads in the same GraphQL response payload - for example using an
-          "incremental" field - this should help to avoid client "thrashing".
+          payloads in the same GraphQL response payload&mdash;for example using
+          an &quot;incremental&quot; field&mdash;this should help to avoid
+          client &quot;thrashing&quot;.
         </p>
       </J>
       <B>
         <p>
-          Definitely more investigation to be done here, but there’s at least
-          consensus to put the start index in the path.
+          Definitely more investigation to be done here, but there&apos;s at
+          least consensus to put the start index in the path.
         </p>
         <p>
-          Yaacov then guided the conversation to the topic of "async iterators
-          of iterables," a rather JavaScript-specific topic but one which may
-          have influence on other implementations.
+          Yaacov then guided the conversation to the topic of &quot;async
+          iterators of iterables&quot;, a rather JavaScript&#8208;specific topic
+          but one which may have influence on other implementations.
         </p>
       </B>
       <J>
-        It's common for other implementations to be translations of the
+        It&apos;s common for other implementations to be translations of the
         reference implementation into other programming languages.
       </J>
       <B>
@@ -158,8 +158,9 @@ export const ep0001: EpisodeDetails = {
       <J>
         The question also extended to returning the data in this shape via the
         GraphQL response, however it was pointed out that after compression the
-        difference between the solutions would be marginal so this shouldn't be
-        a weighty consideration. Further discussion was redirected to{" "}
+        difference between the solutions would be marginal so this
+        shouldn&apos;t be a weighty consideration. Further discussion was
+        redirected to{" "}
         <a
           href="https://github.com/graphql/graphql-wg/discussions/939"
           target="_new"

--- a/src/episodes/0001.tsx
+++ b/src/episodes/0001.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import type { EpisodeDetails } from "./interfaces";
+import { Transcript, J, B, Timestamp } from "../components/Transcript";
 
 export const ep0001: EpisodeDetails = {
   id: "ep0001",
@@ -28,5 +29,53 @@ export const ep0001: EpisodeDetails = {
         .
       </p>
     </div>
+  ),
+  transcript: (
+    <Transcript>
+      <B>
+        Welcome to episode 1 of Spec News</B>
+      <J>
+        keeping you up to date with advances in the GraphQL Spec and related foundation projects.
+      </J>
+      <B>
+        We're your bespectacled hosts: I'm Benjie
+      </B>
+      <J>
+        and I'm Jem.
+        April’s working group saw the announcement of the GraphQL Foundation’s first Conference
+      </J>
+      <B>a preview of the future direction of GraphiQL</B>
+      <J>
+      a proposal to allow unions to implement interfaces
+      </J>
+      <B>
+      and a discussion of the payload format to use for streams
+      </B>
+      <J>
+        The first item was rather exciting - Lee introduced the first official conference organised by the GraphQL Foundation. To make things easier, the conference will be colocated with OpenJSWorld on June 7th and 8th in Austin, but it's important to note that the GraphQL part is not JavaScript-specific!
+      </J>
+      <B>
+        Rather than being an end-user conference, the audience is expected to consist of working group attendees, GraphQL implementers, and other people well versed in topics around the GraphQL specification. Very exciting - get your talk submissions in now!
+      </B>
+      <Timestamp>[Time Stamp] Title</Timestamp>
+      <J>
+
+      </J>
+      <B>
+        
+      </B>
+      <J>
+
+      </J>
+      <B>
+
+      </B>
+      <J>
+
+      </J>
+      <B>
+
+      </B>
+    </Transcript>
   ),
 };

--- a/src/episodes/0001.tsx
+++ b/src/episodes/0001.tsx
@@ -32,50 +32,147 @@ export const ep0001: EpisodeDetails = {
   ),
   transcript: (
     <Transcript>
-      <B>
-        Welcome to episode 1 of Spec News</B>
+      <B>Welcome to episode 1 of Spec News</B>
       <J>
-        keeping you up to date with advances in the GraphQL Spec and related foundation projects.
+        keeping you up to date with advances in the GraphQL Spec and related
+        foundation projects.
       </J>
-      <B>
-        We're your bespectacled hosts: I'm Benjie
-      </B>
+      <B>We're your bespectacled hosts: I'm Benjie</B>
       <J>
         and I'm Jem.
-        April’s working group saw the announcement of the GraphQL Foundation’s first Conference
+        <p>
+          April’s working group saw the announcement of the GraphQL Foundation’s
+          first Conference
+        </p>
       </J>
       <B>a preview of the future direction of GraphiQL</B>
+      <J>a proposal to allow unions to implement interfaces</J>
+      <B>and a discussion of the payload format to use for streams</B>
+      <Timestamp>[0:33] GraphQL Foundation Conference</Timestamp>
       <J>
-      a proposal to allow unions to implement interfaces
+        The first item was rather exciting - Lee introduced the{" "}
+        <a href="https://graphql.org/foundation/graphql-conf/" target="_new">
+          first official conference organised by the GraphQL Foundation
+        </a>
+        . To make things easier, the conference will be colocated with
+        OpenJSWorld on June 7th and 8th in Austin, but it's important to note
+        that the GraphQL part is not JavaScript-specific!
       </J>
       <B>
-      and a discussion of the payload format to use for streams
+        Rather than being an end-user conference, the audience is expected to
+        consist of working group attendees, GraphQL implementers, and other
+        people well versed in topics around the GraphQL specification. Very
+        exciting - get your talk submissions in now!
+      </B>
+      <Timestamp>[1:11] Update on GraphiQL</Timestamp>
+      <J>Tim joined us to give us an update on the GraphiQL&mdash;</J>
+      <B>that's Graph i Q L – the GraphQL IDE</B>
+      <J>
+        &mdash;version 2 design proposals. What was presented looks fantastic -
+        a minimalist and flexible design that expands as you become more
+        familiar. The reception was very positive, tempered only by the working
+        group attendees suggesting improvements to the design, for example
+        allowing additional space for longer-form markdown documentation,
+        improving discoverability of variables, and other such matters. I hope
+        Tim found the feedback helpful and we can't wait to see the project
+        advance!
+      </J>
+      <Timestamp>[1:54] Unions declaring interfaces</Timestamp>
+      <B>
+        Next up was Yaacov with a proposal to allow unions to declare
+        implementation of interfaces. After some discussion this boiled down to
+        a constraint - the union doesn't itself implement the interfaces,
+        instead it requires that all object types within it implement the
+        interfaces - an interesting proposal. The working group pushed Yaacov to
+        consider allowing fields in the interface to be resolved directly on the
+        selection set (without the need for a fragment) for consistency with
+        interfaces elsewhere in the spec. The balance as always is between
+        simplicity and power.
       </B>
       <J>
-        The first item was rather exciting - Lee introduced the first official conference organised by the GraphQL Foundation. To make things easier, the conference will be colocated with OpenJSWorld on June 7th and 8th in Austin, but it's important to note that the GraphQL part is not JavaScript-specific!
+        To advance the proposal further, Lee suggested that Yaacov:
+        <ul>
+          <li>
+            details the impact on execution and particularly on selection sets;
+          </li>
+          <li>looks for and documents precedent from other languages;</li>
+          <li>
+            and considers if a different keyword rather than "implements" would
+            make sense.
+          </li>
+        </ul>
+        The proposal was advanced to RFC stage 1 - &quot;Proposal&quot;.
       </J>
-      <B>
-        Rather than being an end-user conference, the audience is expected to consist of working group attendees, GraphQL implementers, and other people well versed in topics around the GraphQL specification. Very exciting - get your talk submissions in now!
-      </B>
-      <Timestamp>[Time Stamp] Title</Timestamp>
+      <B>And may well make it harder for me to deprecate unions!</B>
+      <Timestamp>[3:01] The payload format to use for streams</Timestamp>
       <J>
-
+        Champion of the defer and stream proposals, Rob, was up next discussing
+        the payload format to use for streams. It was established that nulls
+        must bubble only to the boundary of the payload and no further
+      </J>
+      <B>(since you can't go back in time)</B>
+      <J>
+        indeed; however the challenge is in distinguishing between actual nulls
+        and errors.
       </J>
       <B>
-        
+        For defer, the value is always an object, so returning null is obviously
+        an error, but you can stream any data type.
       </B>
       <J>
-
+        <p>
+          The current proposal is that the stream data should always be wrapped
+          in a list, so that nulls stand out. After discussion this was
+          generally agreed.
+        </p>
+        <p>
+          Further discussion occurred around whether the index should be
+          included in the payload, and if so: where? One consideration here is
+          potential future batching which was discussed in some depth, along
+          with possible payload shapes for including multiple stream or defer
+          payloads in the same GraphQL response payload - for example using an
+          "incremental" field - this should help to avoid client "thrashing".
+        </p>
       </J>
       <B>
-
+        <p>
+          Definitely more investigation to be done here, but there’s at least
+          consensus to put the start index in the path.
+        </p>
+        <p>
+          Yaacov then guided the conversation to the topic of "async iterators
+          of iterables," a rather JavaScript-specific topic but one which may
+          have influence on other implementations.
+        </p>
       </B>
       <J>
-
+        It's common for other implementations to be translations of the
+        reference implementation into other programming languages.
       </J>
       <B>
-
+        The motivation around returning iterators rather than the values
+        directly is one centred around efficiency; going back to the runloop
+        after every value could be quite expensive compared to processing
+        multiple values in the same runloop tick.
       </B>
+      <J>
+        The question also extended to returning the data in this shape via the
+        GraphQL response, however it was pointed out that after compression the
+        difference between the solutions would be marginal so this shouldn't be
+        a weighty consideration. Further discussion was redirected to{" "}
+        <a
+          href="https://github.com/graphql/graphql-wg/discussions/939"
+          target="_new"
+        >
+          GitHub discussions
+        </a>{" "}
+        since the meeting was over time.
+      </J>
+      <B>
+        And with that, that's all from us at Spec News and we bid you a fond
+        farewell.
+      </B>
+      <J>Cheerio!</J>
     </Transcript>
   ),
 };

--- a/src/episodes/0002.tsx
+++ b/src/episodes/0002.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import type { EpisodeDetails } from "./interfaces";
+import { Transcript, J, B, Timestamp } from "../components/Transcript";
 
 export const ep0002: EpisodeDetails = {
   id: "ep0002",
@@ -28,5 +29,168 @@ export const ep0002: EpisodeDetails = {
         .
       </p>
     </div>
+  ),
+  transcript: (
+    <Transcript>
+      <B>Welcome to episode 2 of Spec News</B>
+      <J>
+        keeping you up to date with advances in the GraphQL Spec and related
+        foundation projects.
+      </J>
+      <B>We&apos;re your bespectacled hosts: I&apos;m Benjie</B>
+      <J>
+        and I&apos;m Jem.
+        <p>
+          May&apos;s working group saw the return of discussions around higher
+          order abstract types in GraphQL
+        </p>
+      </J>
+      <B>
+        the availability of a canary release of client&#8208;controlled
+        nullability
+      </B>
+      <J>
+        discussions around the shape of iterables and payloads for defer and
+        stream
+      </J>
+      <B>
+        and the advancement of &quot;oneof input objects&quot; to RFC stage 2.
+      </B>
+      <Timestamp>[0:xx] Action Items</Timestamp>
+      <J>
+        Action items&mdash;following up from Benjie creating a SECURITY policy
+        in the graphql&#8208;wg repo, Benjie suggested extending this policy to
+        all Foundation projects and gained approval to do so.
+      </J>
+      <Timestamp>[0:xx] Higher order abstract types</Timestamp>
+      <B>
+        Yaacov returned with a new proposal following up from the &quot;unions
+        implementing interfaces&quot; proposal from the last working group. This
+        new proposal introduces a new type, the &quot;intersection type&quot;,
+        which would allow us to apply tighter constraints to the abstract types
+        used in a GraphQL schema. Yaacov believes that &quot;second order
+        abstract types&quot; would be a good addition to the GraphQL language.
+      </B>
+      <J>
+        One of the issues raised was that this approach could lead to silent
+        failures, where something does not meet the constraints and is
+        unexpectedly silently omitted rather than noisily failing. There is,
+        however, interest in this issue being solved as it allows clients to
+        rely on fields existing on types that are newly added to a union.
+      </J>
+      <B>
+        Lee cautioned us that implicit versus explicit is generally a tradeoff
+        against expressiveness&mdash;the more expressive you can be, the closer
+        you are to Turing completeness, and you have to do more work to compute
+        the effects of your actions. GraphQL has been designed carefully to make
+        things obvious by just looking at local types&mdash;without having to
+        follow chains&mdash;and an abstract type over abstract types would break
+        that.
+      </B>
+      <J>
+        This revelation gave greater confidence in Yaacov&apos;s original
+        proposal to constrain unions to only include types that implement
+        certain interfaces. Yaacov is going to refine the tests ready for next
+        working group.
+      </J>
+      <Timestamp>[1:54] Unions declaring interfaces</Timestamp>
+      <B>
+        Next up was Yaacov with a proposal to allow unions to declare
+        implementation of interfaces. After some discussion this boiled down to
+        a constraint&mdash;the union doesn&apos;t itself implement the
+        interfaces, instead it requires that all object types within it
+        implement the interfaces&mdash;an interesting proposal. The working
+        group pushed Yaacov to consider allowing fields in the interface to be
+        resolved directly on the selection set (without the need for a fragment)
+        for consistency with interfaces elsewhere in the spec. The balance as
+        always is between simplicity and power.
+      </B>
+      <J>
+        To advance the proposal further, Lee suggested that Yaacov:
+        <ul>
+          <li>
+            details the impact on execution and particularly on selection sets;
+          </li>
+          <li>looks for and documents precedent from other languages;</li>
+          <li>
+            and considers if a different keyword rather than
+            &quot;implements&quot; would make sense.
+          </li>
+        </ul>
+        The proposal was advanced to RFC stage 1: &quot;Proposal&quot;.
+      </J>
+      <B>And may well make it harder for me to deprecate unions!</B>
+      <Timestamp>[3:01] The payload format to use for streams</Timestamp>
+      <J>
+        Champion of the defer and stream proposals, Rob, was up next discussing
+        the payload format to use for streams. It was established that nulls
+        must bubble only to the boundary of the payload and no further
+      </J>
+      <B>(since you can&apos;t go back in time)</B>
+      <J>
+        indeed; however the challenge is in distinguishing between actual nulls
+        and errors.
+      </J>
+      <B>
+        For defer, the value is always an object, so returning null is obviously
+        an error, but you can stream any data type.
+      </B>
+      <J>
+        <p>
+          The current proposal is that the stream data should always be wrapped
+          in a list, so that nulls stand out. After discussion this was
+          generally agreed.
+        </p>
+        <p>
+          Further discussion occurred around whether the index should be
+          included in the payload, and if so: where? One consideration here is
+          potential future batching which was discussed in some depth, along
+          with possible payload shapes for including multiple stream or defer
+          payloads in the same GraphQL response payload&mdash;for example using
+          an &quot;incremental&quot; field&mdash;this should help to avoid
+          client &quot;thrashing&quot;.
+        </p>
+      </J>
+      <B>
+        <p>
+          Definitely more investigation to be done here, but there&apos;s at
+          least consensus to put the start index in the path.
+        </p>
+        <p>
+          Yaacov then guided the conversation to the topic of &quot;async
+          iterators of iterables&quot;, a rather JavaScript&#8208;specific topic
+          but one which may have influence on other implementations.
+        </p>
+      </B>
+      <J>
+        It&apos;s common for other implementations to be translations of the
+        reference implementation into other programming languages.
+      </J>
+      <B>
+        The motivation around returning iterators rather than the values
+        directly is one centred around efficiency; going back to the runloop
+        after every value could be quite expensive compared to processing
+        multiple values in the same runloop tick.
+      </B>
+      <J>
+        The question also extended to returning the data in this shape via the
+        GraphQL response, however it was pointed out that after compression the
+        difference between the solutions would be marginal so this
+        shouldn&apos;t be a weighty consideration. Further discussion was
+        redirected to{" "}
+        <a
+          href="https://github.com/graphql/graphql-wg/discussions/939"
+          target="_new"
+        >
+          GitHub discussions
+        </a>{" "}
+        since the meeting was over time.
+      </J>
+      <B>
+        And with that, that's all from us at Spec News and we bid you a fond
+        farewell.
+      </B>
+      <J>Cheerio!</J>
+    </Transcript>
   ),
 };

--- a/src/episodes/0002.tsx
+++ b/src/episodes/0002.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import type { EpisodeDetails } from "./interfaces";
-import { Transcript, J, B, Timestamp } from "../components/Transcript";
+import { Transcript, J, B, Timestamp, Code } from "../components/Transcript";
 
 export const ep0002: EpisodeDetails = {
   id: "ep0002",
@@ -11,11 +11,12 @@ export const ep0002: EpisodeDetails = {
   description: (
     <div>
       <p>
-        May 2022's working group saw the return of discussions around higher
-        order abstract types in GraphQL, the availability of a canary release of
-        client-controlled nullability, discussions around the shape of iterables
-        and payloads for defer and stream and the advancement of "oneof input
-        objects" to RFC stage 2. Join hosts Benjie and Jem for the details!
+        May 2022&apos;s working group saw the return of discussions around
+        higher order abstract types in GraphQL, the availability of a canary
+        release of client-controlled nullability, discussions around the shape
+        of iterables and payloads for defer and stream and the advancement of{" "}
+        <Code>&#64;oneof</Code> input objects to RFC stage 2. Join hosts Benjie
+        and Jem for the details!
       </p>
       <p>
         Music by{" "}
@@ -54,15 +55,16 @@ export const ep0002: EpisodeDetails = {
         stream
       </J>
       <B>
-        and the advancement of &quot;oneof input objects&quot; to RFC stage 2.
+        and the advancement of <Code>&#64;oneof</Code> input objects&quot; to
+        RFC stage 2.
       </B>
-      <Timestamp>[0:xx] Action Items</Timestamp>
+      <Timestamp>[0:34] Action Items</Timestamp>
       <J>
         Action items&mdash;following up from Benjie creating a SECURITY policy
         in the graphql&#8208;wg repo, Benjie suggested extending this policy to
         all Foundation projects and gained approval to do so.
       </J>
-      <Timestamp>[0:xx] Higher order abstract types</Timestamp>
+      <Timestamp>[0:51] Higher order abstract types</Timestamp>
       <B>
         Yaacov returned with a new proposal following up from the &quot;unions
         implementing interfaces&quot; proposal from the last working group. This
@@ -93,104 +95,90 @@ export const ep0002: EpisodeDetails = {
         certain interfaces. Yaacov is going to refine the tests ready for next
         working group.
       </J>
-      <Timestamp>[1:54] Unions declaring interfaces</Timestamp>
+      <Timestamp>[2:18] Client&#8208;controlled nullability update</Timestamp>
       <B>
-        Next up was Yaacov with a proposal to allow unions to declare
-        implementation of interfaces. After some discussion this boiled down to
-        a constraint&mdash;the union doesn&apos;t itself implement the
-        interfaces, instead it requires that all object types within it
-        implement the interfaces&mdash;an interesting proposal. The working
-        group pushed Yaacov to consider allowing fields in the interface to be
-        resolved directly on the selection set (without the need for a fragment)
-        for consistency with interfaces elsewhere in the spec. The balance as
-        always is between simplicity and power.
+        Alex returned with an update on the status of client&#8208;controlled
+        nullability: there's a canary release of the functionality in
+        graphql&#8208;js and the latest HotChocolate supports it in .NET too.
+        Apollo are also working on support for it.
       </B>
       <J>
-        To advance the proposal further, Lee suggested that Yaacov:
-        <ul>
-          <li>
-            details the impact on execution and particularly on selection sets;
-          </li>
-          <li>looks for and documents precedent from other languages;</li>
-          <li>
-            and considers if a different keyword rather than
-            &quot;implements&quot; would make sense.
-          </li>
-        </ul>
-        The proposal was advanced to RFC stage 1: &quot;Proposal&quot;.
-      </J>
-      <B>And may well make it harder for me to deprecate unions!</B>
-      <Timestamp>[3:01] The payload format to use for streams</Timestamp>
-      <J>
-        Champion of the defer and stream proposals, Rob, was up next discussing
-        the payload format to use for streams. It was established that nulls
-        must bubble only to the boundary of the payload and no further
-      </J>
-      <B>(since you can&apos;t go back in time)</B>
-      <J>
-        indeed; however the challenge is in distinguishing between actual nulls
-        and errors.
+        One of the concerns raised was that applying client&#8208;controlled
+        nullability operators in one fragment may break another fragment
+        that&apos;s defined in another part of the codebase; though this
+        isn&apos;t something that should stop the proposal, it&apos;s definitely
+        a trade&#8208;off worth being aware of.
       </J>
       <B>
-        For defer, the value is always an object, so returning null is obviously
-        an error, but you can stream any data type.
+        Lee tasked Alex with creating discussion threads to help resolve the
+        outstanding questions with the proposals. A discussion around naming
+        arose again, suggesting that &quot;assertion&quot; may be a better name
+        for the bang symbol, and &quot;error boundary&quot; for the question
+        mark symbol.
       </B>
       <J>
-        <p>
-          The current proposal is that the stream data should always be wrapped
-          in a list, so that nulls stand out. After discussion this was
-          generally agreed.
-        </p>
-        <p>
-          Further discussion occurred around whether the index should be
-          included in the payload, and if so: where? One consideration here is
-          potential future batching which was discussed in some depth, along
-          with possible payload shapes for including multiple stream or defer
-          payloads in the same GraphQL response payload&mdash;for example using
-          an &quot;incremental&quot; field&mdash;this should help to avoid
-          client &quot;thrashing&quot;.
-        </p>
+        Ivan is keen to establish the names before they get merged into
+        GraphQL&#8208;js for fear of future breaking changes.
       </J>
+      <Timestamp>
+        [3:15] Defer/Stream: asynchronous iterators of iterables versus of items
+      </Timestamp>
       <B>
-        <p>
-          Definitely more investigation to be done here, but there&apos;s at
-          least consensus to put the start index in the path.
-        </p>
-        <p>
-          Yaacov then guided the conversation to the topic of &quot;async
-          iterators of iterables&quot;, a rather JavaScript&#8208;specific topic
-          but one which may have influence on other implementations.
-        </p>
+        Yaacov next with a continuation of the asynchronous iterators of
+        iterables topic from last meeting.
       </B>
       <J>
-        It&apos;s common for other implementations to be translations of the
-        reference implementation into other programming languages.
+        There was general agreement that if we have batches of data available to
+        us on the backend, we should deliver batches of data to the
+        client&mdash;not least because it influences the way that clients will
+        handle these payloads. However, returning iterators where a VALUE would
+        normally be expected&mdash;simply because it&apos;s a stream&mdash;would
+        be surprising and would give a strange developer experience.
       </J>
       <B>
-        The motivation around returning iterators rather than the values
-        directly is one centred around efficiency; going back to the runloop
-        after every value could be quite expensive compared to processing
-        multiple values in the same runloop tick.
+        However, enforcing that an iterator is always returned might help avoid
+        developers facing the trap that is client thrashing. At this point,
+        discussion seemed to be relatively javascript&#8208;centric, so was
+        redirected to asynchronous channels.
       </B>
+      <Timestamp>[4:04] Defer/Stream: Stream Payload index format</Timestamp>
       <J>
-        The question also extended to returning the data in this shape via the
-        GraphQL response, however it was pointed out that after compression the
-        difference between the solutions would be marginal so this
-        shouldn&apos;t be a weighty consideration. Further discussion was
-        redirected to{" "}
-        <a
-          href="https://github.com/graphql/graphql-wg/discussions/939"
-          target="_new"
-        >
-          GitHub discussions
-        </a>{" "}
-        since the meeting was over time.
+        Rob returned with discussion of the index format in stream payloads; it
+        has been established since the last working group that including the
+        index is essential otherwise ambiguities can occur. Since the
+        append&#8208;only mechanism has been ruled out, discussion centered
+        around choosing between &quot;at index&quot;, &quot;at indices&quot; and
+        &quot;including the index in the path&quot;.
       </J>
       <B>
-        And with that, that's all from us at Spec News and we bid you a fond
-        farewell.
+        The conclusion was that the operation is &quot;set at a range, where the
+        range starts at the index given in the path, and the length of the range
+        is the length of the data.&quot; Though this makes
+        out&#8208;of&#8208;order delivery and sparse lists trickier, it was
+        agreed that the benefits in terms of simplicity outweighed these
+        concerns.
       </B>
-      <J>Cheerio!</J>
+      <Timestamp>
+        [4:50] <Code>&#64;oneof</Code> input objects RFC
+      </Timestamp>
+      <J>
+        Next up was Benjie with a request to advance <Code>&#64;oneof</Code>{" "}
+        input objects to RFC stage 2: &quot;Draft&quot;. Benjie&apos;s main
+        hesitation is around intent to extend <Code>&#64;oneof</Code> to output
+        types&mdash;concerned that if we never choose to add oneof to output
+        types then the significant differences between <Code>&#64;oneof</Code>{" "}
+        inputs versus unions and interfaces could make it undesirable. The
+        working group reassured that <Code>&#64;oneof</Code> input objects seems
+        to be the better input union solution independent of whether it&apos;s
+        available on output or not.
+      </J>
+      <B>
+        Having established that, it was clear that the proposal was ready to
+        advance and has been raised to RFC2 status. And with that, the meeting
+        drew to an end a mere one minute over time, and that's all from us at
+        Spec News! We bid you a fond farewell.
+      </B>
+      <J>Ta ra!</J>
     </Transcript>
   ),
 };

--- a/src/episodes/0002.tsx
+++ b/src/episodes/0002.tsx
@@ -15,7 +15,7 @@ export const ep0002: EpisodeDetails = {
         higher order abstract types in GraphQL, the availability of a canary
         release of client-controlled nullability, discussions around the shape
         of iterables and payloads for defer and stream and the advancement of{" "}
-        <Code>&#64;oneof</Code> input objects to RFC stage 2. Join hosts Benjie
+        <Code>&#64;oneOf</Code> input objects to RFC stage 2. Join hosts Benjie
         and Jem for the details!
       </p>
       <p>
@@ -55,7 +55,7 @@ export const ep0002: EpisodeDetails = {
         stream
       </J>
       <B>
-        and the advancement of <Code>&#64;oneof</Code> input objects&quot; to
+        and the advancement of <Code>&#64;oneOf</Code> input objects&quot; to
         RFC stage 2.
       </B>
       <Timestamp>[0:34] Action Items</Timestamp>
@@ -159,16 +159,16 @@ export const ep0002: EpisodeDetails = {
         concerns.
       </B>
       <Timestamp>
-        [4:50] <Code>&#64;oneof</Code> input objects RFC
+        [4:50] <Code>&#64;oneOf</Code> input objects RFC
       </Timestamp>
       <J>
-        Next up was Benjie with a request to advance <Code>&#64;oneof</Code>{" "}
+        Next up was Benjie with a request to advance <Code>&#64;oneOf</Code>{" "}
         input objects to RFC stage 2: &quot;Draft&quot;. Benjie&apos;s main
-        hesitation is around intent to extend <Code>&#64;oneof</Code> to output
-        types&mdash;concerned that if we never choose to add oneof to output
-        types then the significant differences between <Code>&#64;oneof</Code>{" "}
+        hesitation is around intent to extend <Code>&#64;oneOf</Code> to output
+        types&mdash;concerned that if we never choose to add oneOf to output
+        types then the significant differences between <Code>&#64;oneOf</Code>{" "}
         inputs versus unions and interfaces could make it undesirable. The
-        working group reassured that <Code>&#64;oneof</Code> input objects seems
+        working group reassured that <Code>&#64;oneOf</Code> input objects seems
         to be the better input union solution independent of whether it&apos;s
         available on output or not.
       </J>

--- a/src/episodes/0002.tsx
+++ b/src/episodes/0002.tsx
@@ -33,28 +33,28 @@ export const ep0002: EpisodeDetails = {
   ),
   transcript: (
     <Transcript>
-      <B>Welcome to episode 2 of Spec News</B>
-      <J>
+      <B x>Welcome to episode 2 of Spec News</B>
+      <J x>
         keeping you up to date with advances in the GraphQL Spec and related
         foundation projects.
       </J>
-      <B>We&apos;re your bespectacled hosts: I&apos;m Benjie</B>
-      <J>
+      <B x>We&apos;re your bespectacled hosts: I&apos;m Benjie</B>
+      <J x>
         and I&apos;m Jem.
-        <p>
-          May&apos;s working group saw the return of discussions around higher
-          order abstract types in GraphQL
-        </p>
+        <br />
+        <br />
+        May&apos;s working group saw the return of discussions around higher
+        order abstract types in GraphQL
       </J>
-      <B>
+      <B x>
         the availability of a canary release of client&#8208;controlled
         nullability
       </B>
-      <J>
+      <J x>
         discussions around the shape of iterables and payloads for defer and
         stream
       </J>
-      <B>
+      <B x>
         and the advancement of <Code>&#64;oneOf</Code> input objects&quot; to
         RFC stage 2.
       </B>
@@ -121,7 +121,7 @@ export const ep0002: EpisodeDetails = {
         GraphQL&#8208;js for fear of future breaking changes.
       </J>
       <Timestamp>
-        [3:15] Defer/Stream: asynchronous iterators of iterables versus of items
+        [3:15] Defer/Stream: Asynchronous iterators of iterables versus of items
       </Timestamp>
       <B>
         Yaacov next with a continuation of the asynchronous iterators of
@@ -141,7 +141,7 @@ export const ep0002: EpisodeDetails = {
         discussion seemed to be relatively javascript&#8208;centric, so was
         redirected to asynchronous channels.
       </B>
-      <Timestamp>[4:04] Defer/Stream: Stream Payload index format</Timestamp>
+      <Timestamp>[4:04] Defer/Stream: Stream payload index format</Timestamp>
       <J>
         Rob returned with discussion of the index format in stream payloads; it
         has been established since the last working group that including the

--- a/src/episodes/0003.tsx
+++ b/src/episodes/0003.tsx
@@ -11,12 +11,13 @@ export const ep0003: EpisodeDetails = {
   description: (
     <div>
       <p>
-        June 2022's working-group-meeting saw the closure of a number of action
-        items, the introduction of a new "composite schemas" working group, a
-        discussion around an “experimental” directive, a new validation rule to
-        assert operation types exist, an update on the client-controlled
-        nullability, oneOf, and "unions implementing interfaces" RFCs and a
-        number of spicy takes on the GraphQL spec itself!
+        June 2022&apos;s working group meeting saw the closure of a number of
+        action items, the introduction of a new &quot;composite schemas&quot;
+        working group, a discussion around an <Code>&#64;experimental</Code>{" "}
+        directive, a new validation rule to assert operation types exist, an
+        update on the client-controlled nullability, <Code>&#64;oneOf</Code>,
+        and &quot;unions implementing interfaces&quot; RFCs and a number of
+        spicy takes on the GraphQL spec itself!
       </p>
       <p>
         Music by{" "}
@@ -33,7 +34,7 @@ export const ep0003: EpisodeDetails = {
   ),
   transcript: (
     <Transcript>
-      <B>Welcome to episode 2 of Spec News</B>
+      <B>Welcome to episode 3 of Spec News</B>
       <J>
         keeping you up to date with advances in the GraphQL Spec and related
         foundation projects.
@@ -42,143 +43,254 @@ export const ep0003: EpisodeDetails = {
       <J>
         and I&apos;m Jem.
         <p>
-          May&apos;s working group saw the return of discussions around higher
-          order abstract types in GraphQL
+          June 2022&apos;s working-group-meeting saw the closure of a number of
+          action items
         </p>
       </J>
       <B>
-        the availability of a canary release of client&#8208;controlled
-        nullability
+        the introduction of a new &quot;composite schemas&quot; working group
       </B>
       <J>
-        discussions around the shape of iterables and payloads for defer and
-        stream
+        a discussion around an <Code>&#64;experimental</Code> directive
       </J>
-      <B>
-        and the advancement of <Code>&#64;oneof</Code> input objects&quot; to
-        RFC stage 2.
-      </B>
-      <Timestamp>[0:34] Action Items</Timestamp>
+      <B>a new validation rule to assert operation types exist</B>
       <J>
-        Action items&mdash;following up from Benjie creating a SECURITY policy
-        in the graphql&#8208;wg repo, Benjie suggested extending this policy to
-        all Foundation projects and gained approval to do so.
+        an update on the client-controlled nullability, <Code>&#64;oneOf</Code>,
+        and &quot;unions implementing interfaces&quot; RFCs
       </J>
-      <Timestamp>[0:51] Higher order abstract types</Timestamp>
       <B>
-        Yaacov returned with a new proposal following up from the &quot;unions
-        implementing interfaces&quot; proposal from the last working group. This
-        new proposal introduces a new type, the &quot;intersection type&quot;,
-        which would allow us to apply tighter constraints to the abstract types
-        used in a GraphQL schema. Yaacov believes that &quot;second order
-        abstract types&quot; would be a good addition to the GraphQL language.
+        and a number of spicy takes on the GraphQL spec itself&mdash;let&apos;s
+        get into it!
       </B>
+      <Timestamp>[0:xx] Action items</Timestamp>
       <J>
-        One of the issues raised was that this approach could lead to silent
-        failures, where something does not meet the constraints and is
-        unexpectedly silently omitted rather than noisily failing. There is,
-        however, interest in this issue being solved as it allows clients to
-        rely on fields existing on types that are newly added to a union.
+        <p>
+          First up: action items. Benjie has added a SECURITY document to the
+          .github repo so all foundation projects now have a security policy.
+          Further, he submitted an editorial PR clarifying that the term
+          &quot;request&quot; is independent of transport&mdash;i.e. it does not
+          refer to an HTTP request.
+        </p>
+        <p>
+          Benjie also raised awareness of a suggestion to either increase the
+          length of the working group meetings, or to increase their cadence,
+          and predicted that this meeting would overrun. Before March 2021, the
+          meetings were 3 hours long, but were shortened to 2 hours to help make
+          attendance easier. Further discussion should take place in{" "}
+          <a
+            href="https://github.com/graphql/graphql-wg/issues/988"
+            target="_new"
+          >
+            working group issue #988
+          </a>
+          .
+        </p>
       </J>
+      <Timestamp>[0:xx] Composite schemas working group</Timestamp>
       <B>
-        Lee cautioned us that implicit versus explicit is generally a tradeoff
-        against expressiveness&mdash;the more expressive you can be, the closer
-        you are to Turing completeness, and you have to do more work to compute
-        the effects of your actions. GraphQL has been designed carefully to make
-        things obvious by just looking at local types&mdash;without having to
-        follow chains&mdash;and an abstract type over abstract types would break
-        that.
-      </B>
-      <J>
-        This revelation gave greater confidence in Yaacov&apos;s original
-        proposal to constrain unions to only include types that implement
-        certain interfaces. Yaacov is going to refine the tests ready for next
-        working group.
-      </J>
-      <Timestamp>[2:18] Client&#8208;controlled nullability update</Timestamp>
-      <B>
-        Alex returned with an update on the status of client&#8208;controlled
-        nullability: there's a canary release of the functionality in
-        graphql&#8208;js and the latest HotChocolate supports it in .NET too.
-        Apollo are also working on support for it.
-      </B>
-      <J>
-        One of the concerns raised was that applying client&#8208;controlled
-        nullability operators in one fragment may break another fragment
-        that&apos;s defined in another part of the codebase; though this
-        isn&apos;t something that should stop the proposal, it&apos;s definitely
-        a trade&#8208;off worth being aware of.
-      </J>
-      <B>
-        Lee tasked Alex with creating discussion threads to help resolve the
-        outstanding questions with the proposals. A discussion around naming
-        arose again, suggesting that &quot;assertion&quot; may be a better name
-        for the bang symbol, and &quot;error boundary&quot; for the question
-        mark symbol.
-      </B>
-      <J>
-        Ivan is keen to establish the names before they get merged into
-        GraphQL&#8208;js for fear of future breaking changes.
-      </J>
-      <Timestamp>
-        [3:15] Defer/Stream: asynchronous iterators of iterables versus of items
-      </Timestamp>
-      <B>
-        Yaacov next with a continuation of the asynchronous iterators of
-        iterables topic from last meeting.
-      </B>
-      <J>
-        There was general agreement that if we have batches of data available to
-        us on the backend, we should deliver batches of data to the
-        client&mdash;not least because it influences the way that clients will
-        handle these payloads. However, returning iterators where a VALUE would
-        normally be expected&mdash;simply because it&apos;s a stream&mdash;would
-        be surprising and would give a strange developer experience.
-      </J>
-      <B>
-        However, enforcing that an iterator is always returned might help avoid
-        developers facing the trap that is client thrashing. At this point,
-        discussion seemed to be relatively javascript&#8208;centric, so was
-        redirected to asynchronous channels.
-      </B>
-      <Timestamp>[4:04] Defer/Stream: Stream Payload index format</Timestamp>
-      <J>
-        Rob returned with discussion of the index format in stream payloads; it
-        has been established since the last working group that including the
-        index is essential otherwise ambiguities can occur. Since the
-        append&#8208;only mechanism has been ruled out, discussion centered
-        around choosing between &quot;at index&quot;, &quot;at indices&quot; and
-        &quot;including the index in the path&quot;.
-      </J>
-      <B>
-        The conclusion was that the operation is &quot;set at a range, where the
-        range starts at the index given in the path, and the length of the range
-        is the length of the data.&quot; Though this makes
-        out&#8208;of&#8208;order delivery and sparse lists trickier, it was
-        agreed that the benefits in terms of simplicity outweighed these
-        concerns.
+        The composite schemas working group was proposed by yours truly&mdash;a
+        working group to look at the commonality between all the various
+        &quot;composite schema&quot; approaches: stitching, merging, federation,
+        joins, etc. It gained significant interest and all the key players were
+        already on board when the spec working group officially approved it as a
+        subcommittee. Interested parties should add themselves to the{" "}
+        <a
+          href="https://github.com/graphql/graphql-wg/blob/main/rfcs/CompositeSchemas.md"
+          target="_new"
+        >
+          RFC document via pull request
+        </a>
+        , and an initial meeting will be announced in the next few weeks.
       </B>
       <Timestamp>
-        [4:50] <Code>&#64;oneof</Code> input objects RFC
+        [0:xx] <Code>&#64;experimental</Code> directive
       </Timestamp>
       <J>
-        Next up was Benjie with a request to advance <Code>&#64;oneof</Code>{" "}
-        input objects to RFC stage 2: &quot;Draft&quot;. Benjie&apos;s main
-        hesitation is around intent to extend <Code>&#64;oneof</Code> to output
-        types&mdash;concerned that if we never choose to add oneof to output
-        types then the significant differences between <Code>&#64;oneof</Code>{" "}
-        inputs versus unions and interfaces could make it undesirable. The
-        working group reassured that <Code>&#64;oneof</Code> input objects seems
-        to be the better input union solution independent of whether it&apos;s
-        available on output or not.
+        New attendee Martin has proposed a new <Code>&#64;experimental</Code>{" "}
+        directive&mdash;
+      </J>
+      <B>that's a directive named &quot;experimental&quot;</B>
+      <J>
+        <p>
+          &mdash;which is the counterpart of deprecated. Where{" "}
+          <Code>&#64;deprecated</Code> marks a previously stable field as one
+          which you should no longer use, <Code>&#64;experimental</Code> marks a
+          new field as unstable and so not suitable for production usage yet.
+        </p>
+        <p>
+          There was a lot of interest and discussion around the proposal, with
+          comments indicating similar functionality was already in use at
+          GitHub, Netflix and other companies; showing it's definitely a need.
+          Next steps are to explore alternative solutions, such as creating an{" "}
+          <Code>&#64;opt-in</Code> directive&mdash;
+        </p>
+      </J>
+      <B>that's a directive named &quot;opt-in&quot;</B>
+      <J>&mdash;which could work a little like feature flagging.</J>
+      <Timestamp>
+        [3:xx] Add validation rule that operation types exist
+      </Timestamp>
+      <B>
+        Another new attendee, Ben, has pointed out that the GraphQL Spec doesn't
+        have a validation rule to prevent mutation operations against a schema
+        that does not support mutations; of course they won't actually execute,
+        but this lack of validation causes confusing results in tooling.{" "}
+        <a
+          href="https://github.com/graphql/graphql-spec/pull/955"
+          target="_new"
+        >
+          Ben has proposed to add this simple validation rule
+        </a>{" "}
+        and it immediately jumped to RFC1 without any pushback; I imagine it has
+        a very good chance of becoming RFC2 at the next working group since it
+        already has an implementation in place.
+      </B>
+      <Timestamp>[3:xx] Client-controlled nullability update</Timestamp>
+      <J>
+        Client-controlled nullability champion Alex has raised discussion
+        threads around both{" "}
+        <a
+          href="https://github.com/graphql/graphql-wg/discussions/965"
+          target="_new"
+        >
+          the naming of the RFC itself
+        </a>
+        , and around{" "}
+        <a
+          href="https://github.com/graphql/graphql-wg/discussions/994"
+          target="_new"
+        >
+          the naming of the symbols in the AST
+        </a>
+        .
       </J>
       <B>
-        Having established that, it was clear that the proposal was ready to
-        advance and has been raised to RFC2 status. And with that, the meeting
-        drew to an end a mere one minute over time, and that's all from us at
-        Spec News! We bid you a fond farewell.
+        For those unfamiliar, client-controlled nullability was originally
+        proposed to allow the client to indicate that it wanted to override the
+        nullability of a given field by applying an operator to it, though
+        it&apos;s evolved since then to be more akin to <Code>try-catch</Code>,
+        hence the search for a new name.
       </B>
-      <J>Ta ra!</J>
+      <J>
+        Whilst giving us an update, Alex let us know that the operators now need
+        to strictly match during field merging; a restriction that wasn't
+        previously the case. Though Relay plans to strip the operators before
+        sending to the server, this may cause issues for other clients that rely
+        on fragment isolation. Alex will be providing more details about it
+        soon.
+      </J>
+      <B>
+        And then something unprecedented happened… we voted through the power of
+        emoji to take a 4 minute break!
+      </B>
+      <Timestamp>
+        [4:xx] <Code>&#64;oneOf</Code> update
+      </Timestamp>
+      <J>
+        <p>
+          Returning to the meeting, Benjie gave an update on the{" "}
+          <Code>&#64;oneOf</Code> input objects RFC. This RFC achieved RFC2
+          during the <a href="/ep0002">May working group</a>, and is currently
+          flirting with RFC3&mdash;though it&apos;s not getting anywhere yet!
+        </p>
+        <p>
+          A couple of small changes were made: the introspection field{" "}
+          <Code>oneOf</Code> was renamed to <Code>isOneOf</Code> to match{" "}
+          <Code>isDeprecated</Code>, and a rule was added forbidding{" "}
+          <Code>&#64;oneOf</Code> to be applied to an input object extension.
+          Benjie also raised a draft PR for oneOf objects&mdash;
+        </p>
+      </J>
+      <B>
+        i.e. <Code>&#64;oneOf</Code> for outputs rather than inputs
+      </B>
+      <J>
+        <p>
+          &mdash;and that was immediately marked RFC zero. The purpose of this
+          work in progress RFC was to determine if there was likely to be any
+          inconsistencies between an input <Code>&#64;oneOf</Code> and an output{" "}
+          <Code>&#64;oneOf</Code>; the main outcome of which was questions
+          around whether the unselected fields must be omitted, or can be
+          included but null.
+        </p>
+        <p>
+          The desire is still to omit them, but it was worth the investigation.
+        </p>
+        <p>
+          The working group are still uncertain around the expressed nullability
+          of <Code>&#64;oneOf</Code> input fields, this still seems to be the
+          main sticking point. A suggestion around changing the representation
+          of <Code>&#64;oneOf</Code> in the SDL syntax was quickly shot down, a
+          directive is the preferred approach due to the reduced complexity
+          there.
+        </p>
+      </J>
+      <Timestamp>[4:xx]</Timestamp>
+      <B>
+        <p>
+          Yaacov returned with an update on &quot;unions implementing
+          interfaces&quot;. There was a question around the <Code>fields</Code>{" "}
+          introspection property for a union that implements interfaces;
+          normally a union does not have fields, but as Lee points out
+          everything that implements interfaces right now must also declare its
+          fields. To progress this RFC further, Yaacov must demonstrate that the
+          value added by the feature outweighs the additional complexity it
+          introduces.
+        </p>
+        <p>
+          Yaacov then went on to talk about an alternative proposal&mdash;the
+          ability to include interfaces and unions within a union.
+        </p>
+      </B>
+      <J>
+        Currently unions may only contain concrete object types, not abstract
+        types.
+      </J>
+      <B>
+        Yaacov feels that this change would be simpler, but the non-obvious
+        introspection consequences made Lee rather nervous. Though schema build
+        tooling could mostly handle this concern, there is value in reflecting
+        the underlying unions and interfaces through introspection as it may
+        improve legibility of the API in tools such as GraphiQL. Yaacov
+        commented that his main motivations are addressing the needs that people
+        are expressing via the GraphQL Spec issues repository, so even if we
+        don't solve these problems at least explaining why we haven't solved
+        them would be a valuable outcome.
+      </B>
+      <J>Valuable indeed!</J>
+      <Timestamp>[xx:xx] Editorial changes to the Spec</Timestamp>
+      <J>
+        Next up was Roman who recently{" "}
+        <a
+          href="https://github.com/graphql/graphql-wg/discussions/969"
+          target="_new"
+        >
+          filed a discussion against the GraphQL Spec
+        </a>{" "}
+        containing 29 small issues in the spec. Lee advised that splitting the
+        issues into smaller pull requests and issues, one per topic, would make
+        them much easier to address as it would be much easier for people to
+        weigh in. More in-depth issues could be raised as proposals.
+      </J>
+      <B>
+        Roman went on to give a 10 minute presentation on the issues he saw in
+        the specification, sharing with the working group his understanding of
+        the publishing industry, suggesting significant restructuring of the
+        specification and a number of spicy takes including suggesting that many
+        of the algorithms in the specification should be removed in order to
+        make it shorter and to &quot;not offend programmers&quot;.
+      </B>
+      <J>
+        Unfortunately the meeting overran so there wasn&apos;t much time to
+        discuss these takes, nor to hear Ivan&apos;s eagerly awaited proposal to
+        solve adding metadata to the introspection system, but I&apos;m sure
+        we&apos;ll have time for these things in future working groups.
+      </J>
+      <B>
+        And with that, that&apos;s all from us at Spec News and we bid you a
+        fond farewell.
+      </B>
+      <J>Laters gators!</J>
     </Transcript>
   ),
 };

--- a/src/episodes/0003.tsx
+++ b/src/episodes/0003.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import type { EpisodeDetails } from "./interfaces";
+import { Transcript, J, B, Timestamp, Code } from "../components/Transcript";
 
 export const ep0003: EpisodeDetails = {
   id: "ep0003",
@@ -29,5 +30,155 @@ export const ep0003: EpisodeDetails = {
         .
       </p>
     </div>
+  ),
+  transcript: (
+    <Transcript>
+      <B>Welcome to episode 2 of Spec News</B>
+      <J>
+        keeping you up to date with advances in the GraphQL Spec and related
+        foundation projects.
+      </J>
+      <B>We&apos;re your bespectacled hosts: I&apos;m Benjie</B>
+      <J>
+        and I&apos;m Jem.
+        <p>
+          May&apos;s working group saw the return of discussions around higher
+          order abstract types in GraphQL
+        </p>
+      </J>
+      <B>
+        the availability of a canary release of client&#8208;controlled
+        nullability
+      </B>
+      <J>
+        discussions around the shape of iterables and payloads for defer and
+        stream
+      </J>
+      <B>
+        and the advancement of <Code>&#64;oneof</Code> input objects&quot; to
+        RFC stage 2.
+      </B>
+      <Timestamp>[0:34] Action Items</Timestamp>
+      <J>
+        Action items&mdash;following up from Benjie creating a SECURITY policy
+        in the graphql&#8208;wg repo, Benjie suggested extending this policy to
+        all Foundation projects and gained approval to do so.
+      </J>
+      <Timestamp>[0:51] Higher order abstract types</Timestamp>
+      <B>
+        Yaacov returned with a new proposal following up from the &quot;unions
+        implementing interfaces&quot; proposal from the last working group. This
+        new proposal introduces a new type, the &quot;intersection type&quot;,
+        which would allow us to apply tighter constraints to the abstract types
+        used in a GraphQL schema. Yaacov believes that &quot;second order
+        abstract types&quot; would be a good addition to the GraphQL language.
+      </B>
+      <J>
+        One of the issues raised was that this approach could lead to silent
+        failures, where something does not meet the constraints and is
+        unexpectedly silently omitted rather than noisily failing. There is,
+        however, interest in this issue being solved as it allows clients to
+        rely on fields existing on types that are newly added to a union.
+      </J>
+      <B>
+        Lee cautioned us that implicit versus explicit is generally a tradeoff
+        against expressiveness&mdash;the more expressive you can be, the closer
+        you are to Turing completeness, and you have to do more work to compute
+        the effects of your actions. GraphQL has been designed carefully to make
+        things obvious by just looking at local types&mdash;without having to
+        follow chains&mdash;and an abstract type over abstract types would break
+        that.
+      </B>
+      <J>
+        This revelation gave greater confidence in Yaacov&apos;s original
+        proposal to constrain unions to only include types that implement
+        certain interfaces. Yaacov is going to refine the tests ready for next
+        working group.
+      </J>
+      <Timestamp>[2:18] Client&#8208;controlled nullability update</Timestamp>
+      <B>
+        Alex returned with an update on the status of client&#8208;controlled
+        nullability: there's a canary release of the functionality in
+        graphql&#8208;js and the latest HotChocolate supports it in .NET too.
+        Apollo are also working on support for it.
+      </B>
+      <J>
+        One of the concerns raised was that applying client&#8208;controlled
+        nullability operators in one fragment may break another fragment
+        that&apos;s defined in another part of the codebase; though this
+        isn&apos;t something that should stop the proposal, it&apos;s definitely
+        a trade&#8208;off worth being aware of.
+      </J>
+      <B>
+        Lee tasked Alex with creating discussion threads to help resolve the
+        outstanding questions with the proposals. A discussion around naming
+        arose again, suggesting that &quot;assertion&quot; may be a better name
+        for the bang symbol, and &quot;error boundary&quot; for the question
+        mark symbol.
+      </B>
+      <J>
+        Ivan is keen to establish the names before they get merged into
+        GraphQL&#8208;js for fear of future breaking changes.
+      </J>
+      <Timestamp>
+        [3:15] Defer/Stream: asynchronous iterators of iterables versus of items
+      </Timestamp>
+      <B>
+        Yaacov next with a continuation of the asynchronous iterators of
+        iterables topic from last meeting.
+      </B>
+      <J>
+        There was general agreement that if we have batches of data available to
+        us on the backend, we should deliver batches of data to the
+        client&mdash;not least because it influences the way that clients will
+        handle these payloads. However, returning iterators where a VALUE would
+        normally be expected&mdash;simply because it&apos;s a stream&mdash;would
+        be surprising and would give a strange developer experience.
+      </J>
+      <B>
+        However, enforcing that an iterator is always returned might help avoid
+        developers facing the trap that is client thrashing. At this point,
+        discussion seemed to be relatively javascript&#8208;centric, so was
+        redirected to asynchronous channels.
+      </B>
+      <Timestamp>[4:04] Defer/Stream: Stream Payload index format</Timestamp>
+      <J>
+        Rob returned with discussion of the index format in stream payloads; it
+        has been established since the last working group that including the
+        index is essential otherwise ambiguities can occur. Since the
+        append&#8208;only mechanism has been ruled out, discussion centered
+        around choosing between &quot;at index&quot;, &quot;at indices&quot; and
+        &quot;including the index in the path&quot;.
+      </J>
+      <B>
+        The conclusion was that the operation is &quot;set at a range, where the
+        range starts at the index given in the path, and the length of the range
+        is the length of the data.&quot; Though this makes
+        out&#8208;of&#8208;order delivery and sparse lists trickier, it was
+        agreed that the benefits in terms of simplicity outweighed these
+        concerns.
+      </B>
+      <Timestamp>
+        [4:50] <Code>&#64;oneof</Code> input objects RFC
+      </Timestamp>
+      <J>
+        Next up was Benjie with a request to advance <Code>&#64;oneof</Code>{" "}
+        input objects to RFC stage 2: &quot;Draft&quot;. Benjie&apos;s main
+        hesitation is around intent to extend <Code>&#64;oneof</Code> to output
+        types&mdash;concerned that if we never choose to add oneof to output
+        types then the significant differences between <Code>&#64;oneof</Code>{" "}
+        inputs versus unions and interfaces could make it undesirable. The
+        working group reassured that <Code>&#64;oneof</Code> input objects seems
+        to be the better input union solution independent of whether it&apos;s
+        available on output or not.
+      </J>
+      <B>
+        Having established that, it was clear that the proposal was ready to
+        advance and has been raised to RFC2 status. And with that, the meeting
+        drew to an end a mere one minute over time, and that's all from us at
+        Spec News! We bid you a fond farewell.
+      </B>
+      <J>Ta ra!</J>
+    </Transcript>
   ),
 };

--- a/src/episodes/0003.tsx
+++ b/src/episodes/0003.tsx
@@ -34,35 +34,34 @@ export const ep0003: EpisodeDetails = {
   ),
   transcript: (
     <Transcript>
-      <B>Welcome to episode 3 of Spec News</B>
-      <J>
+      <B x>Welcome to episode 3 of Spec News</B>
+      <J x>
         keeping you up to date with advances in the GraphQL Spec and related
         foundation projects.
       </J>
-      <B>We&apos;re your bespectacled hosts: I&apos;m Benjie</B>
-      <J>
-        and I&apos;m Jem.
-        <p>
-          June 2022&apos;s working-group-meeting saw the closure of a number of
-          action items
-        </p>
+      <B x>We&apos;re your bespectacled hosts: I&apos;m Benjie</B>
+      <J x>
+        and I&apos;m Jem. <br />
+        <br />
+        June 2022&apos;s working-group-meeting saw the closure of a number of
+        action items
       </J>
-      <B>
+      <B x>
         the introduction of a new &quot;composite schemas&quot; working group
       </B>
-      <J>
+      <J x>
         a discussion around an <Code>&#64;experimental</Code> directive
       </J>
-      <B>a new validation rule to assert operation types exist</B>
-      <J>
+      <B x>a new validation rule to assert operation types exist</B>
+      <J x>
         an update on the client-controlled nullability, <Code>&#64;oneOf</Code>,
         and &quot;unions implementing interfaces&quot; RFCs
       </J>
-      <B>
+      <B x>
         and a number of spicy takes on the GraphQL spec itself&mdash;let&apos;s
         get into it!
       </B>
-      <Timestamp>[0:xx] Action items</Timestamp>
+      <Timestamp>[0:45] Action items</Timestamp>
       <J>
         <p>
           First up: action items. Benjie has added a SECURITY document to the
@@ -86,7 +85,7 @@ export const ep0003: EpisodeDetails = {
           .
         </p>
       </J>
-      <Timestamp>[0:xx] Composite schemas working group</Timestamp>
+      <Timestamp>[1:30] Composite schemas working group</Timestamp>
       <B>
         The composite schemas working group was proposed by yours truly&mdash;a
         working group to look at the commonality between all the various
@@ -103,13 +102,13 @@ export const ep0003: EpisodeDetails = {
         , and an initial meeting will be announced in the next few weeks.
       </B>
       <Timestamp>
-        [0:xx] <Code>&#64;experimental</Code> directive
+        [2:02] <Code>&#64;experimental</Code> directive
       </Timestamp>
       <J>
         New attendee Martin has proposed a new <Code>&#64;experimental</Code>{" "}
         directive&mdash;
       </J>
-      <B>that's a directive named &quot;experimental&quot;</B>
+      <B x>that's a directive named &quot;experimental&quot;</B>
       <J>
         <p>
           &mdash;which is the counterpart of deprecated. Where{" "}
@@ -125,10 +124,10 @@ export const ep0003: EpisodeDetails = {
           <Code>&#64;opt-in</Code> directive&mdash;
         </p>
       </J>
-      <B>that's a directive named &quot;opt-in&quot;</B>
+      <B x>that's a directive named &quot;opt-in&quot;</B>
       <J>&mdash;which could work a little like feature flagging.</J>
       <Timestamp>
-        [3:xx] Add validation rule that operation types exist
+        [2:48] Add validation rule that operation types exist
       </Timestamp>
       <B>
         Another new attendee, Ben, has pointed out that the GraphQL Spec doesn't
@@ -145,7 +144,7 @@ export const ep0003: EpisodeDetails = {
         a very good chance of becoming RFC2 at the next working group since it
         already has an implementation in place.
       </B>
-      <Timestamp>[3:xx] Client-controlled nullability update</Timestamp>
+      <Timestamp>[3:19] Client-controlled nullability update</Timestamp>
       <J>
         Client-controlled nullability champion Alex has raised discussion
         threads around both{" "}
@@ -184,7 +183,7 @@ export const ep0003: EpisodeDetails = {
         emoji to take a 4 minute break!
       </B>
       <Timestamp>
-        [4:xx] <Code>&#64;oneOf</Code> update
+        [4:15] <Code>&#64;oneOf</Code> update
       </Timestamp>
       <J>
         <p>
@@ -198,10 +197,11 @@ export const ep0003: EpisodeDetails = {
           <Code>oneOf</Code> was renamed to <Code>isOneOf</Code> to match{" "}
           <Code>isDeprecated</Code>, and a rule was added forbidding{" "}
           <Code>&#64;oneOf</Code> to be applied to an input object extension.
-          Benjie also raised a draft PR for oneOf objects&mdash;
+          Benjie also raised a draft PR for <Code>&#64;oneOf</Code>{" "}
+          objects&mdash;
         </p>
       </J>
-      <B>
+      <B x>
         i.e. <Code>&#64;oneOf</Code> for outputs rather than inputs
       </B>
       <J>
@@ -225,7 +225,7 @@ export const ep0003: EpisodeDetails = {
           there.
         </p>
       </J>
-      <Timestamp>[4:xx]</Timestamp>
+      <Timestamp>[5:39] Unions implementing interfaces</Timestamp>
       <B>
         <p>
           Yaacov returned with an update on &quot;unions implementing
@@ -258,7 +258,7 @@ export const ep0003: EpisodeDetails = {
         them would be a valuable outcome.
       </B>
       <J>Valuable indeed!</J>
-      <Timestamp>[xx:xx] Editorial changes to the Spec</Timestamp>
+      <Timestamp>[6:58] Editorial changes to the Spec</Timestamp>
       <J>
         Next up was Roman who recently{" "}
         <a

--- a/src/episodes/0004.tsx
+++ b/src/episodes/0004.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import type { EpisodeDetails } from "./interfaces";
+import { Transcript, J, B, Timestamp, Code } from "../components/Transcript";
 
 export const ep0004: EpisodeDetails = {
   id: "ep0004",
@@ -39,5 +40,291 @@ export const ep0004: EpisodeDetails = {
         .
       </p>
     </div>
+  ),
+  transcript: (
+    <Transcript>
+      <B x>Hello GraphQL fans! Welcome to episode 4 of Spec News</B>
+      <J x>
+        keeping you up to date with advances in the GraphQL Spec and related
+        foundation projects.
+      </J>
+      <B x>We&apos;re your bespectacled hosts: I&apos;m Benjie</B>
+      <J x>
+        and I&apos;m Jem.
+        <br />
+        <br />
+        July 2022&apos;s working group meeting saw discussion around adding
+        directives to existing enum values,
+      </J>
+      <B x>adding &quot;schema metadata&quot; to SDL and introspection,</B>
+      <J x>
+        allowing recursion when resolving the concrete object type of a value
+        representing an interface or union type,
+      </J>
+      <B x>an update from the GraphQL-over-HTTP working group,</B>
+      <J x>and an update on the defer and stream RFC.</J>
+      <Timestamp>[0:40] Action items</Timestamp>
+      <B>
+        <p>Here we go!</p>
+        <p>
+          First up, action items. There were two action items from June&apos;s
+          meeting, both of which have been addressed:
+          <ul>
+            <li>
+              the composite schemas working group has been created and is due to
+              meet on Thursday 14th July
+            </li>
+            <li>
+              a number of discussions and pull requests have been created (and
+              some merged) related to Roman's specification feedback.
+            </li>
+          </ul>
+        </p>
+      </B>
+      <J>
+        From the backlog:
+        <ul>
+          <li>
+            The "deprecation of input values" has passed Lee's final editorial
+            review and is now in the draft specification! 🎉
+          </li>
+          <li>
+            Rob is still progressing the stream and defer RFC&mdash;more on that
+            later.
+          </li>
+        </ul>
+      </J>
+      <Timestamp>[1:15] Adding directives to existing enum values</Timestamp>
+      <B>On to the main agenda.</B>
+      <J>
+        This month&apos;s first topic came from new Working Group member Benoit.
+        Benoit wants to control how enums are mapped into their native values on
+        certain clients. To do this, he wishes to use the GraphQL &quot;type
+        extensions&quot; syntax to add directives to existing enum values.
+      </J>
+      <B>
+        The type extensions syntax in GraphQL allows you to add directives to
+        existing types and to add enum values to enum types, but it does not
+        allow you to add directives to existing enum values of an enum type.
+        Similarly, it does&apos;t allow you to add directives to an existing
+        field of an object or interface type, even though it can be used to add
+        new fields.
+      </B>
+      <J>
+        <p>
+          Lee explained that the type extensions capability in GraphQL is
+          deliberately very simple. If we were to enable this behaviour on enum
+          values, we&apos;d also expect to have this behaviour on object type
+          fields, which are complex due to field arguments.
+        </p>
+        <p>
+          Michael suggested a custom merge strategy and Matt shared that
+          Facebook uses a custom merge strategy with client-only schema files.
+          Lee suggested the group should revisit the problem itself rather than
+          the proposed solution&mdash;perhaps there&apos;s other ways to apply
+          this metadata to the enum values without using the type extensions
+          syntax. In chat many expressed that this might be a good topic for the
+          composite schemas working group. Stephen shared that Shopify has a
+          dedicated system they use internally for merging metadata back into
+          the schema which allows for different teams to own different parts of
+          the metadata.
+        </p>
+      </J>
+      <B>
+        Hopefully Benoit will return to a future working group meeting with an
+        updated proposal inspired by this feedback.
+      </B>
+      <Timestamp>[2:53] Schema metadata</Timestamp>
+      <B>
+        <p>
+          Next up was the eagerly awaited presentation from Ivan on adding
+          schema &quot;meta&quot; fields to the SDL and introspection.
+        </p>
+        <p>
+          In his presentation, Ivan showed that there are currently two main
+          approaches to add metadata to a GraphQL schema. One is the
+          &quot;SDL&quot; approach&mdash;as used in Apollo
+          Federation&mdash;where the schema contains a string field containing a
+          GraphQL document composed of the schema definition and additional
+          metadata in the form of directives. The other is the &quot;applied
+          directives&quot; approach&mdash;as used in GraphQL Java, Hot Chocolate
+          and others&mdash;whereby directives applied when building the GraphQL
+          schema would be exposed through the introspection schema.
+        </p>
+      </B>
+      <J>
+        Ivan noted Benjie did a{" "}
+        <a href="https://www.youtube.com/watch?v=c1oa7p73rTw" target="_new">
+          great talk on the need for GraphQL Schema metadata
+        </a>{" "}
+        at the recent GraphQL Conference&mdash;there&apos;s a link in this
+        episode&apos;s description.
+      </J>
+      <B>
+        Focussing on the introspection direction, Ivan surfaced some of the
+        shortcomings of the &quot;applied directives&quot; solution. One issue
+        is that due to directives being repeatable and having significant order
+        they would have to be exposed as a list, which is not an ideal way for
+        clients to consume metadata.
+      </B>
+      <J>
+        <p>
+          Ivan suggested making metadata a first class citizen using the{" "}
+          <Code>+</Code> symbol in SDL syntax and exposing via <Code>meta</Code>{" "}
+          fields in introspection.
+        </p>
+        <p>After a short break&mdash;</p>
+      </J>
+      <B x> I like this new trend!</B>
+      <J>
+        &mdash;we returned on the hour for Roman to present his counter
+        arguments, suggesting that we explore the appliedDirectives approach
+        more thoroughly.
+      </J>
+      <B>
+        Roman feels that directives are already metadata, the term being a
+        &quot;historical accident&quot;, and does not want to add another
+        metadata approach. Further, he believes that since directives are
+        committed to git, and git should not contain secrets, all directives are
+        suitable to expose to end users.
+      </B>
+      <J>
+        Since the group were already well over time they agreed Ivan should
+        raise a discussion thread and then moved on to the next topic.
+      </J>
+      <Timestamp>
+        [4:45] Allowing recursion within <Code>ResolveAbstractValue</Code>
+      </Timestamp>
+      <J>
+        Yaacov suggested a small change to the specification to allow for the{" "}
+        <Code>ResolveAbstractType</Code> algorithm to enable
+        recursion&mdash;motivated by the new &quot;interfaces implementing
+        interfaces&quot; feature of GraphQL.
+      </J>
+      <B>
+        <p>
+          This <Code>ResolveAbstractType</Code> algorithm is responsible for
+          taking a runtime value associated with an abstract type (i.e. an
+          interface or union) and figuring out which concrete object type the
+          value represents.
+        </p>
+        <p>Currently the specification states:</p>
+        <p>
+          Return the result of calling the internal method provided by the type
+          system for determining the Object type of abstractType given the value
+          objectValue.
+        </p>
+      </B>
+      <J>
+        Yaacov suggested this &quot;internal method&quot; could return an
+        intermediate type and have GraphQL recurse, rather than having to return
+        the final object type directly (perhaps via recursion in user space).
+      </J>
+      <B>
+        The group were still running short on time, so no specific conclusion
+        was reached but Lee and others will give some feedback on the pull
+        request.
+      </B>
+      <Timestamp>[5:41] GraphQL over HTTP</Timestamp>
+      <J>
+        Next up was Benjie with a small update from the GraphQL over HTTP
+        subcommittee
+      </J>
+      <B>
+        After an extended hiatus, we were interested in pumping some life back
+        into this subcommittee. I kicked us off by rewriting the draft
+        specification with a focus on backwards compatibility and introducing a
+        watershed date of 1st January 2025.
+      </B>
+      <J>
+        The watershed states that from this date all GraphQL services must
+        support the new <Code>application/graphql+json</Code> media type which
+        would finally allow for GraphQL errors to safely be included in non-200
+        status code HTTP responses.
+      </J>
+      <B>
+        Other members of the subcommittee have weighed in to help us get the
+        spec much closer to being release worthy. The GraphQL-over-HTTP
+        subcommittee met in June for the first time since 2020 and are due to
+        meet again on 21st July with the aim of working towards releasing v1 of
+        the GraphQL-over-HTTP specification with the next release of the GraphQL
+        specification (which might be in October, judging by the last release).
+      </B>
+      <J>That's a pretty tight deadline! Good luck!</J>
+      <Timestamp>[6:47] Update on defer/stream</Timestamp>
+      <J>
+        Due to running short on time, a quick agenda modification meant that Rob
+        was up next with updates from the defer and stream RFC. Recent work has
+        focussed around batching of payloads to help avoid the client thrashing
+        issues of delivering many small payloads in quick succession to a
+        client. A general consensus has been reached on this topic, the
+        introduction of the "incremental" field into the response payload, but
+        the specifics around this are still being worked out.
+      </J>
+      <B>
+        There was a long discussion around whether this change meant that we
+        should change the &quot;SHOULD&quot; to a &quot;MUST&quot; when it comes
+        to requiring the server to honour stream/defer directives in the
+        request. Team MUST suggested many potential shapes for the response was
+        undesirable, requiring the client to do more work. Team SHOULD felt the
+        server understands the data better and should be able to determine
+        whether to inline the data or return it via incremental patches. Another
+        comment suggested an edge cache would forward the streamed response the
+        first time, but then immediately return the resolved data object in
+        later requests for both client and server efficiency. General consensus
+        seems to be that we should keep it as a SHOULD for now, but it&apos;s
+        not the 100% consensus that the group generally seeks.
+      </B>
+      <J>
+        Finally Rob asked for contributions to{" "}
+        <a
+          href="https://github.com/robrichard/defer-stream-wg/discussions/42"
+          target="_new"
+        >
+          discussion #42
+        </a>{" "}
+        on the defer-stream-wg repo, discussing the (rather bike-sheddy) topic
+        of whether they should rename &quot;data&quot; to &quot;items&quot; when
+        it comes to stream, since it returns a list rather than an object.
+      </J>
+      <Timestamp>[8:18] Outstanding items</Timestamp>
+      <B>
+        Unfortunately we did not have time to cover the remaining topics which
+        were Roman with an update on the changes he&apos;d like to see in the
+        structure of the GraphQL specification, and my proposal for a{" "}
+        <a href="https://github.com/graphql/graphql-wg/pull/1035" target="_new">
+          &quot;Structured, Type-safe, Returnable and Union Capable Type&quot;
+        </a>{" "}
+        (i.e. the &quot;struct&quot; type&mdash;a composite type suitable for
+        use on both input and output and capable of polymorphism) and how this
+        might weigh in to the metadata discussions. We&apos;ll open some{" "}
+        <a
+          href="https://github.com/graphql/graphql-wg/issues/1058"
+          target="_new"
+        >
+          async discussions
+        </a>{" "}
+        on these topics and hopefully will have time to discuss them at the next
+        meeting.
+      </B>
+      <J>
+        As a final side note, asynchronous discussions over increasing the
+        duration or cadence of GraphQL Spec WG meetings are still ongoing so
+        that they can avoid having to skip topics like this in future&mdash;get
+        involved on graphql-wg{" "}
+        <a
+          href="https://github.com/graphql/graphql-wg/discussions/1051"
+          target="_new"
+        >
+          discussion thread 1051
+        </a>
+        !
+      </J>
+      <B>
+        Phew! That was a packed meeting! That&apos;s all from us at Spec News
+        and we bid you a fond farewell.
+      </B>
+      <J>Ciao for now!</J>
+    </Transcript>
   ),
 };

--- a/src/episodes/interfaces.tsx
+++ b/src/episodes/interfaces.tsx
@@ -5,4 +5,5 @@ export interface EpisodeDetails {
   embed: string;
   date: string;
   description?: JSX.Element;
+  transcript?: JSX.Element;
 }

--- a/src/pages/ep0000.tsx
+++ b/src/pages/ep0000.tsx
@@ -1,0 +1,5 @@
+import React from "react";
+import { EpisodePage } from "../components/EpisodePage";
+import { ep0000 } from "../episodes/0000";
+
+export default () => <EpisodePage episode={ep0000} />;

--- a/src/pages/ep0001.tsx
+++ b/src/pages/ep0001.tsx
@@ -1,0 +1,5 @@
+import React from "react";
+import { EpisodePage } from "../components/EpisodePage";
+import { ep0001 } from "../episodes/0001";
+
+export default () => <EpisodePage episode={ep0001} />;

--- a/src/pages/ep0002.tsx
+++ b/src/pages/ep0002.tsx
@@ -1,0 +1,5 @@
+import React from "react";
+import { EpisodePage } from "../components/EpisodePage";
+import { ep0002 } from "../episodes/0002";
+
+export default () => <EpisodePage episode={ep0002} />;

--- a/src/pages/ep0003.tsx
+++ b/src/pages/ep0003.tsx
@@ -1,0 +1,5 @@
+import React from "react";
+import { EpisodePage } from "../components/EpisodePage";
+import { ep0003 } from "../episodes/0003";
+
+export default () => <EpisodePage episode={ep0003} />;

--- a/src/pages/ep0004.tsx
+++ b/src/pages/ep0004.tsx
@@ -1,0 +1,5 @@
+import React from "react";
+import { EpisodePage } from "../components/EpisodePage";
+import { ep0004 } from "../episodes/0004";
+
+export default () => <EpisodePage episode={ep0004} />;

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,131 +1,13 @@
 import * as React from "react";
 import episodes from "../episodes/index";
 import { Episode } from "../components/Episode";
-import { Channel } from "../components/Channel";
-import { SignupFormLight } from "../components/SignupForm";
 import "../styles/index.css";
-import { Helmet } from "react-helmet";
+import { Hero } from "../components/Hero";
 
 const IndexPage = () => {
   return (
     <div>
-      <Helmet
-        title="SpecNews: a podcast delivering the latest highlights from the GraphQL Working Group"
-        defer={false}
-      >
-        <link
-          rel="apple-touch-icon"
-          sizes="180x180"
-          href="/apple-touch-icon.png"
-        />
-        <link
-          rel="icon"
-          type="image/png"
-          sizes="32x32"
-          href="/favicon-32x32.png"
-        />
-        <link
-          rel="icon"
-          type="image/png"
-          sizes="16x16"
-          href="/favicon-16x16.png"
-        />
-        <meta property="og:type" content="website" />
-        <meta property="og:url" content="https://specnewspod.com/" />
-        <meta property="og:title" content="SpecNews: GraphQL WG Digests" />
-        <meta
-          property="og:description"
-          content="The latest GraphQL Working Group highlights straight to your ears; stay up to date in just a few minutes every month!"
-        />
-        <meta
-          property="og:image"
-          content="https://specnewspod.com/logo/SpecNews.png"
-        />
-        <link
-          type="application/rss+xml"
-          rel="alternate"
-          title="SpecNews: GraphQL digests"
-          href="https://anchor.fm/s/9c882588/podcast/rss"
-        />
-      </Helmet>
-
-      <div className="header">
-        <div className="headerInner">
-          <div className="headerText">
-            <h1>GraphQL Working Group updates in minutes</h1>
-            <div className="headerWho">
-              <div className="headerPerson">
-                <div className="headerPersonAvatar">
-                  <img
-                    src="/avatar/benjie.png"
-                    width="64"
-                    height="64"
-                    alt="Benjie"
-                  />
-                </div>
-                <div className="headerPersonName">
-                  <a href="https://twitter.com/Benjie">@Benjie</a>
-                </div>
-              </div>
-              <div className="headerPerson">
-                <div className="headerPersonAvatar">
-                  <img src="/avatar/jem.jpg" width="64" height="64" alt="Jem" />
-                </div>
-                <div className="headerPersonName">
-                  <a href="https://twitter.com/JemGillam">@JemGillam</a>
-                </div>
-              </div>
-            </div>
-            <p className="lead">
-              <strong>SpecNews</strong> digests the latest GraphQL Working Group
-              happenings and delivers the highlights straight to your ears, so
-              you can stay up to date in just a few minutes every month.
-            </p>
-            <hr />
-            <SignupFormLight />
-            {/*
-            <p>Subscribe to be notified of new episodes of SpecNews:</p>
-            <form className="subscribe">
-              <input placeholder="yourname@example.com" />
-              <button type="submit">Subscribe</button>
-            </form>
-            */}
-            <div className="channels">
-              <Channel
-                name="Spotify"
-                logo="/logo/spotify-brands.svg"
-                url="https://open.spotify.com/show/69vo1Wrlda6EP3EzIZnzjf"
-                title="Subscribe to SpecNews on Spotify"
-              />
-              <Channel
-                name="Apple"
-                logo="/logo/podcast-solid.svg"
-                url="https://podcasts.apple.com/us/podcast/specnews-graphql-digests/id1628494077"
-                title="Subscribe to SpecNews on Apple Podcasts"
-              />
-              <Channel
-                name="RSS"
-                logo="/logo/square-rss-solid.svg"
-                url="https://anchor.fm/s/9c882588/podcast/rss"
-                title="Subscribe via RSS"
-              />
-              <Channel
-                name="Twitter"
-                logo="/logo/twitter-brands.svg"
-                url="https://twitter.com/SpecNewsPod"
-                title="Follow @SpecNewsPod on Twitter"
-              />
-            </div>
-            <p>
-              <small>
-                (Launched 7th June 2022, more channels available shortly)
-              </small>
-            </p>
-          </div>
-          <div className="headerGap"></div>
-          <div className="headerLogo"></div>
-        </div>
-      </div>
+      <Hero />
       <div className="main">
         <main>
           {episodes.map((e, i) => (

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -3,10 +3,12 @@ import episodes from "../episodes/index";
 import { Episode } from "../components/Episode";
 import "../styles/index.css";
 import { Hero } from "../components/Hero";
+import { Meta } from "../components/Meta";
 
 const IndexPage = () => {
   return (
     <div>
+      <Meta />
       <Hero />
       <div className="main">
         <main>

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -166,6 +166,15 @@ main {
   padding-left: 2rem;
 }
 
+.episodeTitles a {
+  color: inherit;
+  text-decoration: none;
+}
+
+.episodeTitles a:hover {
+  text-decoration: underline;
+}
+
 .episodeMeta {
   font-family: "Source Code Pro", Menlo, Ubuntu, mono;
   font-size: 0.8rem;
@@ -197,6 +206,17 @@ main {
 
 .input--hidden {
   display: none;
+}
+
+a.back {
+  display: inline-block;
+  background-color: rgba(0, 0, 0, 0.3);
+  padding: 1rem 2rem;
+  border-radius: 2rem;
+  margin-left: -2rem;
+  margin-top: 2rem;
+  margin-bottom: 0;
+  color: white;
 }
 
 /* From sib */

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -60,6 +60,15 @@ body {
 .header .channel img {
   vertical-align: bottom;
 }
+.episodeLogo {
+  flex: 0 0 0;
+  min-width: 10rem;
+  min-height: 10rem;
+  background-image: url("/logo/SpecNews.png");
+  background-size: contain;
+  background-position: 50% 50%;
+  background-repeat: no-repeat;
+}
 
 @media only screen and (max-width: 60rem) {
   .header {

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -230,8 +230,7 @@ a.back {
 a.close {
   display: block;
   background-color: rgba(0, 0, 0, 0.3);
-  padding: 1rem;
-  border-radius: 1rem;
+  padding: 0.5rem;
   margin-left: -2rem;
   margin-top: 2rem;
   margin-bottom: 0;

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -227,6 +227,17 @@ a.back {
   margin-bottom: 0;
   color: white;
 }
+a.close {
+  display: block;
+  background-color: rgba(0, 0, 0, 0.3);
+  padding: 1rem;
+  border-radius: 1rem;
+  margin-left: -2rem;
+  margin-top: 2rem;
+  margin-bottom: 0;
+  color: white;
+  float: right;
+}
 
 /* From sib */
 /* <link rel="stylesheet" href="https://sibforms.com/forms/end-form/build/sib-styles.css"> */

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -234,3 +234,27 @@ a.back {
   color: #c0ccda;
 }
 */
+
+.transcriptEntry {
+  margin-bottom: 2rem;
+}
+
+.transcriptSpeaker {
+  position: relative;
+  height: 2em;
+}
+.transcriptSpeakerAvatar {
+  width: 2em;
+  height: 2em;
+}
+.transcriptSpeakerName {
+  position: absolute;
+  top: 0;
+  left: 3rem;
+  font-weight: bold;
+  padding-top: 0.5rem;
+}
+.transcriptText {
+  margin-left: 3rem;
+  padding-top: 0.5rem;
+}

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -247,18 +247,56 @@ a.back {
   width: 2em;
   height: 2em;
 }
+.transcriptSpeakerName, .transcriptSpeakerNameShort {
+  font-weight: bold;
+}
+.transcriptSpeakerNameShort {
+  display: inline-block;
+  padding-left: 1em;
+  width: 4em;
+}
 .transcriptSpeakerName {
   position: absolute;
   top: 0;
   left: 3rem;
-  font-weight: bold;
   padding-top: 0.5rem;
 }
 .transcriptText {
   margin-left: 3rem;
   padding-top: 0.5rem;
 }
+.transcriptText p {
+  margin-top: 0;
+}
 .code {
   font-family: "Source Code Pro", Menlo, Ubuntu, mono;
   background-color: rgba(175, 184, 193, 0.2)
+}
+.transcriptEntryShort {
+  display: flex;
+  margin-bottom: 1rem;
+}
+.avatarShort {
+  flex: 0 0 2em;
+}
+.bodyShort {
+  flex: 1 1 0;
+  margin-top: 0.5em;
+}
+
+.transcriptEntry.short {
+  display: flex;
+  margin-bottom: 1em;
+}
+.short .transcriptSpeaker {
+  flex: 0 0 7em;
+  display: flex;
+}
+.short .transcriptSpeakerName {
+  position:initial;
+  flex: 0 0 4em;
+  margin-left: 1em;
+}
+.short .transcriptText {
+  margin-left: 0rem;
 }

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -258,3 +258,7 @@ a.back {
   margin-left: 3rem;
   padding-top: 0.5rem;
 }
+.code {
+  font-family: "Source Code Pro", Menlo, Ubuntu, mono;
+  background-color: rgba(175, 184, 193, 0.2)
+}


### PR DESCRIPTION
## Description

- Individual episode pages
- Transcripts for episodes 0 - 4
- Uses its own avatars instead of hotlinks to GitHub
- Inline style for the introduction part of the episode
- Timestamps
- Links to various working group discussions and pull requests

Still to go
- Maybe a blockquote style (for episode 4)
- @benjie check the look of the top "back" button. Maybe it needs to be in one of the container divs instead